### PR TITLE
README: A minor adjustment for pip install command to work with Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ development dependencies by running:
 ```shell
 python3 -m venv .venv
 . .venv/bin/activate
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 ## Testing


### PR DESCRIPTION
Without this change, I was getting:

```
$ pip install -e .[dev]
zsh: no matches found: .[dev]
```