### PR TITLE
tests: Python: Fix timezone errors in UTC+1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,12 @@
 #
 # SPDX-License-Identifier: MIT
 
+import json
+import os
 import pytest
 import shutil
 import subprocess
-import json
+import time
 
 from pytest_server_fixtures.http import SimpleHTTPTestServer
 from pathlib import Path
@@ -61,3 +63,23 @@ def test_jsonschema(model_server, test_context_url):
     )
 
     yield json.loads(p.stdout)
+
+
+@pytest.fixture(scope="function")
+def test_timezone():
+    try:
+        current_tz = os.environ["TZ"]
+    except KeyError:
+        current_tz = None
+
+    os.environ["TZ"] = "TST+02"
+    time.tzset()
+
+    try:
+        yield
+    finally:
+        if current_tz is None:
+            del os.environ["TZ"]
+        else:
+            os.environ["TZ"] = current_tz
+        time.tzset()

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -28,6 +28,8 @@ TEST_CONTEXT = THIS_DIR / "data" / "model" / "test-context.json"
 
 SPDX3_CONTEXT_URL = "https://spdx.github.io/spdx-3-model/context.json"
 
+TEST_TZ = timezone(timedelta(hours=-2), name="TST")
+
 
 @pytest.fixture(scope="session")
 def roundtrip(tmp_path_factory, model_server):
@@ -619,8 +621,8 @@ def type_tests(name, *typ):
         (
             # Local time
             "test_class_datetime_scalar_prop",
-            datetime(2024, 3, 11, 0, 0, 0),
-            datetime(2024, 3, 11, 0, 0, 0).astimezone(),
+            lambda _: datetime(2024, 3, 11, 0, 0, 0),
+            datetime(2024, 3, 11, 0, 0, 0, tzinfo=TEST_TZ),
         ),
         (
             # Explict timezone
@@ -643,8 +645,8 @@ def type_tests(name, *typ):
         (
             "test_class_datetime_scalar_prop",
             # Microseconds are ignored
-            datetime(2024, 3, 11, 0, 0, 0, 999),
-            datetime(2024, 3, 11, 0, 0, 0).astimezone(),
+            lambda _: datetime(2024, 3, 11, 0, 0, 0, 999),
+            datetime(2024, 3, 11, 0, 0, 0, tzinfo=TEST_TZ),
         ),
         (
             "test_class_datetime_scalar_prop",
@@ -675,8 +677,8 @@ def type_tests(name, *typ):
         (
             # Local time
             "test_class_datetimestamp_scalar_prop",
-            datetime(2024, 3, 11, 0, 0, 0),
-            datetime(2024, 3, 11, 0, 0, 0).astimezone(),
+            lambda _: datetime(2024, 3, 11, 0, 0, 0),
+            datetime(2024, 3, 11, 0, 0, 0, tzinfo=TEST_TZ),
         ),
         (
             # Explict timezone
@@ -812,7 +814,7 @@ def type_tests(name, *typ):
         ("encode", "foo", AttributeError),
     ],
 )
-def test_scalar_prop_validation(model, prop, value, expect):
+def test_scalar_prop_validation(model, test_timezone, prop, value, expect):
     c = model.test_class()
 
     if callable(value):


### PR DESCRIPTION
If the users timezone happens to match the timezone the tests are looking for, it will result in test failures. Fix this by forcing the timezone to US/Mountain time (UTC+7) when running the tests.

Closes #6