### PR TITLE
model: Fix abstract class detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ with the following turtle:
 
 <MyClass> a owl:Class, sh:NodeShape ;
     # SHACL to prevent a class from being instansiated as this exact type
-    sh:not [
-        sh:class <MyClass>
+    sh:property [
+        sh:path rdf:type ;
+        sh:not [ sh:hasValue <MyClass> ]
     ] .
 
 ```

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -165,10 +165,6 @@ class Model(object):
             if bool(self.model.value(s, SHACL2CODE.isAbstract, default=False)):
                 return True
 
-            for n in self.model.objects(s, SH["not"]):
-                if (n, SH["class"], s) in self.model:
-                    return True
-
             return False
 
         class_iris = set(self.model.subjects(RDF.type, OWL.Class))
@@ -200,6 +196,11 @@ class Model(object):
 
             for obj_prop in self.model.objects(cls_iri, SH.property):
                 prop = self.model.value(obj_prop, SH.path)
+                if prop == RDF.type:
+                    for n in self.model.objects(obj_prop, SH["not"]):
+                        if (n, SH.hasValue, cls_iri) in self.model:
+                            c.is_abstract = True
+                    continue
 
                 p = Property(
                     varname=self.model.value(

--- a/tests/data/model/test.ttl
+++ b/tests/data/model/test.ttl
@@ -491,8 +491,9 @@
 
 <abstract-sh-class> a rdf:Class, sh:NodeShape, owl:Class ;
     rdfs:comment: "An Abstract class using SHACL validation" ;
-    sh:not [
-        sh:class <abstract-sh-class>
+    sh:property [
+        sh:path rdf:type ;
+        sh:not [ sh:hasValue <abstract-sh-class> ]
     ] .
 
 <concrete-class> a rdf:Class, sh:NodeShape, owl:Class ;


### PR DESCRIPTION
The SHACL validated method for detecting abstract classes had a problem in that it would not allow concrete derived subclasses to be construct, since sh:class looks at subclasses also. Instead, use a constraint on rdf:type, which checks the actual declared types of the objects without going into subclasses