### PR TITLE
python: Handle empty object set

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -1265,7 +1265,7 @@ class SHACLObjectSet(object):
                     with list_s.write_list_item() as item_s:
                         o.encode(item_s, state)
 
-        else:
+        elif objects:
             objects[0].encode(encoder, state)
 
     def decode(self, decoder):

--- a/tests/expect/python/context/test-context.py
+++ b/tests/expect/python/context/test-context.py
@@ -1265,7 +1265,7 @@ class SHACLObjectSet(object):
                     with list_s.write_list_item() as item_s:
                         o.encode(item_s, state)
 
-        else:
+        elif objects:
             objects[0].encode(encoder, state)
 
     def decode(self, decoder):

--- a/tests/expect/python/nocontext/test.py
+++ b/tests/expect/python/nocontext/test.py
@@ -1265,7 +1265,7 @@ class SHACLObjectSet(object):
                     with list_s.write_list_item() as item_s:
                         o.encode(item_s, state)
 
-        else:
+        elif objects:
             objects[0].encode(encoder, state)
 
     def decode(self, decoder):


### PR DESCRIPTION
If an objectset had no objects, it would crash when attempt to encode them.