### PR TITLE
python: make StringProp to decode SPDX alias with actual ID

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -96,7 +96,12 @@ class StringProp(Property):
         encoder.write_string(value)
 
     def decode(self, decoder, *, objectset=None):
-        return decoder.read_string()
+        s = decoder.read_string()
+        if is_IRI(s) and objectset:
+            obj = objectset.find_by_id(s)
+            if obj is not None:
+                return obj._id
+        return s
 
 
 class AnyURIProp(StringProp):


### PR DESCRIPTION
This commit make StringProp to decode string as IRI first in which replace SPDX alias with actual ID. For other situation, still return string as usual