### PR TITLE
Golang Improvements

### DIFF
--- a/src/shacl2code/lang/templates/golang/classes.go.j2
+++ b/src/shacl2code/lang/templates/golang/classes.go.j2
@@ -148,13 +148,17 @@ type {{ interface_name(class) }} interface {
     SHACLObject
 {%- endif %}
 {%- for prop in class.properties %}
-{%- if prop_is_list(prop) %}
-    {{ varname(prop.varname) }}() ListPropertyInterface[{{ prop_go_type(prop, classes) }}]
-{%- elif not prop.enum_values and prop.class_id %}
-    {{ varname(prop.varname) }}() RefPropertyInterface[{{ interface_name(classes.get(prop.class_id)) }}]
-{%- else %}
-    {{ varname(prop.varname) }}() PropertyInterface[{{ prop_go_type(prop, classes) }}]
-{%- endif %}
+    {{ varname(prop.varname) }}() {% if not prop.enum_values and prop.class_id -%}
+            Ref
+        {%- endif %}{% if prop_is_list(prop) -%}
+            List
+        {%- endif %}PropertyInterface[
+        {%- if not prop.enum_values and prop.class_id -%}
+            {{ interface_name(classes.get(prop.class_id)) }}
+        {%- else -%}
+            {{ prop_go_type(prop, classes) }}
+        {%- endif -%}
+        ]
 {%- endfor %}
 }
 
@@ -260,13 +264,19 @@ func (self *{{ struct_name(class) }}) Link(state *LinkState) error {
 }
 
 {% for prop in class.properties %}
-{%- if prop_is_list(prop) %}
-func (self *{{ struct_name(class) }}) {{ varname(prop.varname) }}() ListPropertyInterface[{{ prop_go_type(prop, classes) }}] { return &self.{{ prop_name(prop) }} }
-{%- elif not prop.enum_values and prop.class_id %}
-func (self *{{ struct_name(class) }}) {{ varname(prop.varname) }}() RefPropertyInterface[{{ interface_name(classes.get(prop.class_id)) }}] { return &self.{{ prop_name(prop) }} }
-{%- else %}
-func (self *{{ struct_name(class) }}) {{ varname(prop.varname) }}() PropertyInterface[{{ prop_go_type(prop, classes) }}] { return &self.{{ prop_name(prop) }} }
-{%- endif %}
+func (self *{{ struct_name(class) }}) {{ varname(prop.varname) }}() {% if not prop.enum_values and prop.class_id -%}
+            Ref
+        {%- endif %}{% if prop_is_list(prop) -%}
+            List
+        {%- endif %}PropertyInterface[
+        {%- if not prop.enum_values and prop.class_id -%}
+            {{ interface_name(classes.get(prop.class_id)) }}
+        {%- else -%}
+            {{ prop_go_type(prop, classes) }}
+        {%- endif -%}
+        ] {
+    return &self.{{ prop_name(prop) }}
+}
 {%- endfor %}
 
 func (self *{{ struct_name(class) }}) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {

--- a/src/shacl2code/lang/templates/golang/reflistproperty.go.j2
+++ b/src/shacl2code/lang/templates/golang/reflistproperty.go.j2
@@ -8,6 +8,12 @@ vim: ft=go
 
 package {{ package }}
 
+type RefListPropertyInterface[T SHACLObject] interface {
+    ListPropertyInterface[Ref[T]]
+    AppendObj(obj T) error
+    AppendIRI(iri string) error
+}
+
 type RefListProperty[T SHACLObject] struct {
     ListProperty[Ref[T]]
 }
@@ -42,4 +48,15 @@ func (self *RefListProperty[T]) Link(state *LinkState) error {
     }
     return nil
 }
+
+func (self *RefListProperty[T]) AppendObj(obj T) error {
+    // Shorthand to append an object by making a reference to it
+    return self.Append(MakeObjectRef(obj))
+}
+
+func (self *RefListProperty[T]) AppendIRI(iri string) error {
+    // Shorthand to append an IRI by making a reference to it
+    return self.Append(MakeIRIRef[T](iri))
+}
+
 

--- a/src/shacl2code/lang/templates/golang/shaclobjectset.go.j2
+++ b/src/shacl2code/lang/templates/golang/shaclobjectset.go.j2
@@ -11,6 +11,7 @@ package {{ package }}
 import (
     "encoding/json"
     "fmt"
+    "sort"
 )
 
 type SHACLObjectSet interface {
@@ -27,6 +28,46 @@ type SHACLObjectSet interface {
 type SHACLObjectSetObject struct {
     objects []SHACLObject
     missingIDs map[string]bool
+}
+
+
+type shaclObjectList struct {
+    v []SHACLObject
+    idx map[SHACLObject]int
+}
+
+func makeshaclObjectList(lst []SHACLObject) shaclObjectList {
+    idx := make(map[SHACLObject]int)
+    for i, o := range lst {
+        idx[o] = i
+    }
+
+    return shaclObjectList{lst, idx}
+}
+
+func (v shaclObjectList) Len() int {
+    return len(v.v)
+}
+
+func (v shaclObjectList) Swap(i, j int) {
+    v.v[i], v.v[j] = v.v[j], v.v[i]
+}
+
+func (v shaclObjectList) Less(i, j int) bool {
+    if v.v[i].ID().IsSet() {
+        if v.v[j].ID().IsSet() {
+            return v.v[i].ID().Get() < v.v[j].ID().Get()
+        } else {
+            return false;
+        }
+    } else {
+        if v.v[j].ID().IsSet() {
+            return true
+        } else {
+            // Neither has an ID. Preserve original insertion order
+            return v.idx[v.v[i]] < v.idx[v.v[j]]
+        }
+    }
 }
 
 func (self *SHACLObjectSetObject) Objects(yield func(SHACLObject) bool) {
@@ -129,6 +170,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
     }
 
     ref_counts := make(map[SHACLObject]int)
+    top_objects := make(map[SHACLObject]bool)
 
     // Count references
     self.Walk(func (path Path, v any) {
@@ -151,6 +193,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
         ref_counts[o] = ref_counts[o] + 1
     })
 
+    // Assign blank nodes to objects that have more than one reference
     blank_count := 0
     for o, count := range ref_counts {
         if count <= 1 {
@@ -163,25 +206,38 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
 
         o.ID().Set(fmt.Sprintf("_:%d", blank_count))
         blank_count += 1
+        top_objects[o] = true
     }
 
-    if len(self.objects) == 1 {
-        err := self.objects[0].EncodeProperties(data, path, &state)
+    for _, o := range self.objects {
+        top_objects[o] = true
+    }
+
+    // Convert to a list and sort
+    top_list := []SHACLObject{}
+    for o, _ := range top_objects {
+        top_list = append(top_list, o)
+    }
+
+    sort.Sort(makeshaclObjectList(top_list))
+
+    if len(top_list) == 1 {
+        err := top_list[0].EncodeProperties(data, path, &state)
         if err != nil {
             return err
         }
-    } else if len(self.objects) > 1 {
+    } else if len(top_objects) > 1 {
         // All objects directly added to the object set should be written as
         // top level objects, so mark then as written until they are ready to
         // be serialized, which will force them to be referenced by IRI until
         // we are ready
-        for _, o := range self.objects {
+        for _, o := range top_list {
             state.Written[o] = true
         }
 
         graph_path := path.PushPath("@graph")
         lst := []interface{}{}
-        for idx, o := range self.objects {
+        for idx, o := range top_list {
             // Remove this object from the written set now so it gets serialized
             delete(state.Written, o)
 

--- a/src/shacl2code/lang/templates/golang/shaclobjectset.go.j2
+++ b/src/shacl2code/lang/templates/golang/shaclobjectset.go.j2
@@ -204,7 +204,8 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
             continue
         }
 
-        o.ID().Set(fmt.Sprintf("_:%d", blank_count))
+
+        o.ID().Set(fmt.Sprintf("_:%s%d", o.GetType().GetCompactTypeIRI().GetDefault(""), blank_count))
         blank_count += 1
         top_objects[o] = true
     }

--- a/tests/expect/golang/context/test-context/classes.go
+++ b/tests/expect/golang/context/test-context/classes.go
@@ -927,7 +927,7 @@ func ConstructLinkClassObject(o *LinkClassObject, typ SHACLType) *LinkClassObjec
 type LinkClass interface {
     SHACLObject
     LinkClassExtensible() RefPropertyInterface[ExtensibleClass]
-    LinkClassLinkListProp() ListPropertyInterface[Ref[LinkClass]]
+    LinkClassLinkListProp() RefListPropertyInterface[LinkClass]
     LinkClassLinkProp() RefPropertyInterface[LinkClass]
     LinkClassLinkPropNoClass() RefPropertyInterface[LinkClass]
     LinkClassTag() PropertyInterface[string]
@@ -1013,11 +1013,21 @@ func (self *LinkClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *LinkClassObject) LinkClassExtensible() RefPropertyInterface[ExtensibleClass] { return &self.linkClassExtensible }
-func (self *LinkClassObject) LinkClassLinkListProp() ListPropertyInterface[Ref[LinkClass]] { return &self.linkClassLinkListProp }
-func (self *LinkClassObject) LinkClassLinkProp() RefPropertyInterface[LinkClass] { return &self.linkClassLinkProp }
-func (self *LinkClassObject) LinkClassLinkPropNoClass() RefPropertyInterface[LinkClass] { return &self.linkClassLinkPropNoClass }
-func (self *LinkClassObject) LinkClassTag() PropertyInterface[string] { return &self.linkClassTag }
+func (self *LinkClassObject) LinkClassExtensible() RefPropertyInterface[ExtensibleClass] {
+    return &self.linkClassExtensible
+}
+func (self *LinkClassObject) LinkClassLinkListProp() RefListPropertyInterface[LinkClass] {
+    return &self.linkClassLinkListProp
+}
+func (self *LinkClassObject) LinkClassLinkProp() RefPropertyInterface[LinkClass] {
+    return &self.linkClassLinkProp
+}
+func (self *LinkClassObject) LinkClassLinkPropNoClass() RefPropertyInterface[LinkClass] {
+    return &self.linkClassLinkPropNoClass
+}
+func (self *LinkClassObject) LinkClassTag() PropertyInterface[string] {
+    return &self.linkClassTag
+}
 
 func (self *LinkClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -1655,7 +1665,9 @@ func (self *RequiredAbstractObject) Link(state *LinkState) error {
 }
 
 
-func (self *RequiredAbstractObject) RequiredAbstractAbstractClassProp() RefPropertyInterface[AbstractClass] { return &self.requiredAbstractAbstractClassProp }
+func (self *RequiredAbstractObject) RequiredAbstractAbstractClassProp() RefPropertyInterface[AbstractClass] {
+    return &self.requiredAbstractAbstractClassProp
+}
 
 func (self *RequiredAbstractObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -2311,7 +2323,7 @@ type TestClass interface {
     Import() PropertyInterface[string]
     TestClassAnyuriProp() PropertyInterface[string]
     TestClassBooleanProp() PropertyInterface[bool]
-    TestClassClassListProp() ListPropertyInterface[Ref[TestClass]]
+    TestClassClassListProp() RefListPropertyInterface[TestClass]
     TestClassClassProp() RefPropertyInterface[TestClass]
     TestClassClassPropNoClass() RefPropertyInterface[TestClass]
     TestClassDatetimeListProp() ListPropertyInterface[time.Time]
@@ -2625,32 +2637,84 @@ func (self *TestClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *TestClassObject) Encode() PropertyInterface[string] { return &self.encode }
-func (self *TestClassObject) Import() PropertyInterface[string] { return &self.import_ }
-func (self *TestClassObject) TestClassAnyuriProp() PropertyInterface[string] { return &self.testClassAnyuriProp }
-func (self *TestClassObject) TestClassBooleanProp() PropertyInterface[bool] { return &self.testClassBooleanProp }
-func (self *TestClassObject) TestClassClassListProp() ListPropertyInterface[Ref[TestClass]] { return &self.testClassClassListProp }
-func (self *TestClassObject) TestClassClassProp() RefPropertyInterface[TestClass] { return &self.testClassClassProp }
-func (self *TestClassObject) TestClassClassPropNoClass() RefPropertyInterface[TestClass] { return &self.testClassClassPropNoClass }
-func (self *TestClassObject) TestClassDatetimeListProp() ListPropertyInterface[time.Time] { return &self.testClassDatetimeListProp }
-func (self *TestClassObject) TestClassDatetimeScalarProp() PropertyInterface[time.Time] { return &self.testClassDatetimeScalarProp }
-func (self *TestClassObject) TestClassDatetimestampScalarProp() PropertyInterface[time.Time] { return &self.testClassDatetimestampScalarProp }
-func (self *TestClassObject) TestClassEnumListProp() ListPropertyInterface[string] { return &self.testClassEnumListProp }
-func (self *TestClassObject) TestClassEnumProp() PropertyInterface[string] { return &self.testClassEnumProp }
-func (self *TestClassObject) TestClassEnumPropNoClass() PropertyInterface[string] { return &self.testClassEnumPropNoClass }
-func (self *TestClassObject) TestClassFloatProp() PropertyInterface[float64] { return &self.testClassFloatProp }
-func (self *TestClassObject) TestClassIntegerProp() PropertyInterface[int] { return &self.testClassIntegerProp }
-func (self *TestClassObject) NamedProperty() PropertyInterface[string] { return &self.namedProperty }
-func (self *TestClassObject) TestClassNonShape() RefPropertyInterface[NonShapeClass] { return &self.testClassNonShape }
-func (self *TestClassObject) TestClassNonnegativeIntegerProp() PropertyInterface[int] { return &self.testClassNonnegativeIntegerProp }
-func (self *TestClassObject) TestClassPositiveIntegerProp() PropertyInterface[int] { return &self.testClassPositiveIntegerProp }
-func (self *TestClassObject) TestClassRegex() PropertyInterface[string] { return &self.testClassRegex }
-func (self *TestClassObject) TestClassRegexDatetime() PropertyInterface[time.Time] { return &self.testClassRegexDatetime }
-func (self *TestClassObject) TestClassRegexDatetimestamp() PropertyInterface[time.Time] { return &self.testClassRegexDatetimestamp }
-func (self *TestClassObject) TestClassRegexList() ListPropertyInterface[string] { return &self.testClassRegexList }
-func (self *TestClassObject) TestClassStringListNoDatatype() ListPropertyInterface[string] { return &self.testClassStringListNoDatatype }
-func (self *TestClassObject) TestClassStringListProp() ListPropertyInterface[string] { return &self.testClassStringListProp }
-func (self *TestClassObject) TestClassStringScalarProp() PropertyInterface[string] { return &self.testClassStringScalarProp }
+func (self *TestClassObject) Encode() PropertyInterface[string] {
+    return &self.encode
+}
+func (self *TestClassObject) Import() PropertyInterface[string] {
+    return &self.import_
+}
+func (self *TestClassObject) TestClassAnyuriProp() PropertyInterface[string] {
+    return &self.testClassAnyuriProp
+}
+func (self *TestClassObject) TestClassBooleanProp() PropertyInterface[bool] {
+    return &self.testClassBooleanProp
+}
+func (self *TestClassObject) TestClassClassListProp() RefListPropertyInterface[TestClass] {
+    return &self.testClassClassListProp
+}
+func (self *TestClassObject) TestClassClassProp() RefPropertyInterface[TestClass] {
+    return &self.testClassClassProp
+}
+func (self *TestClassObject) TestClassClassPropNoClass() RefPropertyInterface[TestClass] {
+    return &self.testClassClassPropNoClass
+}
+func (self *TestClassObject) TestClassDatetimeListProp() ListPropertyInterface[time.Time] {
+    return &self.testClassDatetimeListProp
+}
+func (self *TestClassObject) TestClassDatetimeScalarProp() PropertyInterface[time.Time] {
+    return &self.testClassDatetimeScalarProp
+}
+func (self *TestClassObject) TestClassDatetimestampScalarProp() PropertyInterface[time.Time] {
+    return &self.testClassDatetimestampScalarProp
+}
+func (self *TestClassObject) TestClassEnumListProp() ListPropertyInterface[string] {
+    return &self.testClassEnumListProp
+}
+func (self *TestClassObject) TestClassEnumProp() PropertyInterface[string] {
+    return &self.testClassEnumProp
+}
+func (self *TestClassObject) TestClassEnumPropNoClass() PropertyInterface[string] {
+    return &self.testClassEnumPropNoClass
+}
+func (self *TestClassObject) TestClassFloatProp() PropertyInterface[float64] {
+    return &self.testClassFloatProp
+}
+func (self *TestClassObject) TestClassIntegerProp() PropertyInterface[int] {
+    return &self.testClassIntegerProp
+}
+func (self *TestClassObject) NamedProperty() PropertyInterface[string] {
+    return &self.namedProperty
+}
+func (self *TestClassObject) TestClassNonShape() RefPropertyInterface[NonShapeClass] {
+    return &self.testClassNonShape
+}
+func (self *TestClassObject) TestClassNonnegativeIntegerProp() PropertyInterface[int] {
+    return &self.testClassNonnegativeIntegerProp
+}
+func (self *TestClassObject) TestClassPositiveIntegerProp() PropertyInterface[int] {
+    return &self.testClassPositiveIntegerProp
+}
+func (self *TestClassObject) TestClassRegex() PropertyInterface[string] {
+    return &self.testClassRegex
+}
+func (self *TestClassObject) TestClassRegexDatetime() PropertyInterface[time.Time] {
+    return &self.testClassRegexDatetime
+}
+func (self *TestClassObject) TestClassRegexDatetimestamp() PropertyInterface[time.Time] {
+    return &self.testClassRegexDatetimestamp
+}
+func (self *TestClassObject) TestClassRegexList() ListPropertyInterface[string] {
+    return &self.testClassRegexList
+}
+func (self *TestClassObject) TestClassStringListNoDatatype() ListPropertyInterface[string] {
+    return &self.testClassStringListNoDatatype
+}
+func (self *TestClassObject) TestClassStringListProp() ListPropertyInterface[string] {
+    return &self.testClassStringListProp
+}
+func (self *TestClassObject) TestClassStringScalarProp() PropertyInterface[string] {
+    return &self.testClassStringScalarProp
+}
 
 func (self *TestClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.ParentClassObject.EncodeProperties(data, path, state); err != nil {
@@ -2994,8 +3058,12 @@ func (self *TestClassRequiredObject) Link(state *LinkState) error {
 }
 
 
-func (self *TestClassRequiredObject) TestClassRequiredStringListProp() ListPropertyInterface[string] { return &self.testClassRequiredStringListProp }
-func (self *TestClassRequiredObject) TestClassRequiredStringScalarProp() PropertyInterface[string] { return &self.testClassRequiredStringScalarProp }
+func (self *TestClassRequiredObject) TestClassRequiredStringListProp() ListPropertyInterface[string] {
+    return &self.testClassRequiredStringListProp
+}
+func (self *TestClassRequiredObject) TestClassRequiredStringScalarProp() PropertyInterface[string] {
+    return &self.testClassRequiredStringScalarProp
+}
 
 func (self *TestClassRequiredObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.TestClassObject.EncodeProperties(data, path, state); err != nil {
@@ -3120,7 +3188,9 @@ func (self *TestDerivedClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *TestDerivedClassObject) TestDerivedClassStringProp() PropertyInterface[string] { return &self.testDerivedClassStringProp }
+func (self *TestDerivedClassObject) TestDerivedClassStringProp() PropertyInterface[string] {
+    return &self.testDerivedClassStringProp
+}
 
 func (self *TestDerivedClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.TestClassObject.EncodeProperties(data, path, state); err != nil {
@@ -3244,7 +3314,9 @@ func (self *UsesExtensibleAbstractClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *UsesExtensibleAbstractClassObject) UsesExtensibleAbstractClassProp() RefPropertyInterface[ExtensibleAbstractClass] { return &self.usesExtensibleAbstractClassProp }
+func (self *UsesExtensibleAbstractClassObject) UsesExtensibleAbstractClassProp() RefPropertyInterface[ExtensibleAbstractClass] {
+    return &self.usesExtensibleAbstractClassProp
+}
 
 func (self *UsesExtensibleAbstractClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -3560,8 +3632,12 @@ func (self *ExtensibleClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *ExtensibleClassObject) ExtensibleClassProperty() PropertyInterface[string] { return &self.extensibleClassProperty }
-func (self *ExtensibleClassObject) ExtensibleClassRequired() PropertyInterface[string] { return &self.extensibleClassRequired }
+func (self *ExtensibleClassObject) ExtensibleClassProperty() PropertyInterface[string] {
+    return &self.extensibleClassProperty
+}
+func (self *ExtensibleClassObject) ExtensibleClassRequired() PropertyInterface[string] {
+    return &self.extensibleClassRequired
+}
 
 func (self *ExtensibleClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.LinkClassObject.EncodeProperties(data, path, state); err != nil {

--- a/tests/expect/golang/context/test-context/reflistproperty.go
+++ b/tests/expect/golang/context/test-context/reflistproperty.go
@@ -6,6 +6,12 @@
 
 package model
 
+type RefListPropertyInterface[T SHACLObject] interface {
+    ListPropertyInterface[Ref[T]]
+    AppendObj(obj T) error
+    AppendIRI(iri string) error
+}
+
 type RefListProperty[T SHACLObject] struct {
     ListProperty[Ref[T]]
 }
@@ -40,3 +46,14 @@ func (self *RefListProperty[T]) Link(state *LinkState) error {
     }
     return nil
 }
+
+func (self *RefListProperty[T]) AppendObj(obj T) error {
+    // Shorthand to append an object by making a reference to it
+    return self.Append(MakeObjectRef(obj))
+}
+
+func (self *RefListProperty[T]) AppendIRI(iri string) error {
+    // Shorthand to append an IRI by making a reference to it
+    return self.Append(MakeIRIRef[T](iri))
+}
+

--- a/tests/expect/golang/context/test-context/shaclobjectset.go
+++ b/tests/expect/golang/context/test-context/shaclobjectset.go
@@ -194,7 +194,8 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
             continue
         }
 
-        o.ID().Set(fmt.Sprintf("_:%d", blank_count))
+
+        o.ID().Set(fmt.Sprintf("_:%s%d", o.GetType().GetCompactTypeIRI().GetDefault(""), blank_count))
         blank_count += 1
         top_objects[o] = true
     }

--- a/tests/expect/golang/context/test-context/shaclobjectset.go
+++ b/tests/expect/golang/context/test-context/shaclobjectset.go
@@ -9,6 +9,7 @@ package model
 import (
     "encoding/json"
     "fmt"
+    "sort"
 )
 
 type SHACLObjectSet interface {
@@ -25,6 +26,46 @@ type SHACLObjectSet interface {
 type SHACLObjectSetObject struct {
     objects []SHACLObject
     missingIDs map[string]bool
+}
+
+
+type shaclObjectList struct {
+    v []SHACLObject
+    idx map[SHACLObject]int
+}
+
+func makeshaclObjectList(lst []SHACLObject) shaclObjectList {
+    idx := make(map[SHACLObject]int)
+    for i, o := range lst {
+        idx[o] = i
+    }
+
+    return shaclObjectList{lst, idx}
+}
+
+func (v shaclObjectList) Len() int {
+    return len(v.v)
+}
+
+func (v shaclObjectList) Swap(i, j int) {
+    v.v[i], v.v[j] = v.v[j], v.v[i]
+}
+
+func (v shaclObjectList) Less(i, j int) bool {
+    if v.v[i].ID().IsSet() {
+        if v.v[j].ID().IsSet() {
+            return v.v[i].ID().Get() < v.v[j].ID().Get()
+        } else {
+            return false;
+        }
+    } else {
+        if v.v[j].ID().IsSet() {
+            return true
+        } else {
+            // Neither has an ID. Preserve original insertion order
+            return v.idx[v.v[i]] < v.idx[v.v[j]]
+        }
+    }
 }
 
 func (self *SHACLObjectSetObject) Objects(yield func(SHACLObject) bool) {
@@ -119,6 +160,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
     }
 
     ref_counts := make(map[SHACLObject]int)
+    top_objects := make(map[SHACLObject]bool)
 
     // Count references
     self.Walk(func (path Path, v any) {
@@ -141,6 +183,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
         ref_counts[o] = ref_counts[o] + 1
     })
 
+    // Assign blank nodes to objects that have more than one reference
     blank_count := 0
     for o, count := range ref_counts {
         if count <= 1 {
@@ -153,25 +196,38 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
 
         o.ID().Set(fmt.Sprintf("_:%d", blank_count))
         blank_count += 1
+        top_objects[o] = true
     }
 
-    if len(self.objects) == 1 {
-        err := self.objects[0].EncodeProperties(data, path, &state)
+    for _, o := range self.objects {
+        top_objects[o] = true
+    }
+
+    // Convert to a list and sort
+    top_list := []SHACLObject{}
+    for o, _ := range top_objects {
+        top_list = append(top_list, o)
+    }
+
+    sort.Sort(makeshaclObjectList(top_list))
+
+    if len(top_list) == 1 {
+        err := top_list[0].EncodeProperties(data, path, &state)
         if err != nil {
             return err
         }
-    } else if len(self.objects) > 1 {
+    } else if len(top_objects) > 1 {
         // All objects directly added to the object set should be written as
         // top level objects, so mark then as written until they are ready to
         // be serialized, which will force them to be referenced by IRI until
         // we are ready
-        for _, o := range self.objects {
+        for _, o := range top_list {
             state.Written[o] = true
         }
 
         graph_path := path.PushPath("@graph")
         lst := []interface{}{}
-        for idx, o := range self.objects {
+        for idx, o := range top_list {
             // Remove this object from the written set now so it gets serialized
             delete(state.Written, o)
 

--- a/tests/expect/golang/nocontext/test/classes.go
+++ b/tests/expect/golang/nocontext/test/classes.go
@@ -927,7 +927,7 @@ func ConstructHttpExampleOrgLinkClassObject(o *HttpExampleOrgLinkClassObject, ty
 type HttpExampleOrgLinkClass interface {
     SHACLObject
     Extensible() RefPropertyInterface[HttpExampleOrgExtensibleClass]
-    LinkListProp() ListPropertyInterface[Ref[HttpExampleOrgLinkClass]]
+    LinkListProp() RefListPropertyInterface[HttpExampleOrgLinkClass]
     LinkProp() RefPropertyInterface[HttpExampleOrgLinkClass]
     LinkPropNoClass() RefPropertyInterface[HttpExampleOrgLinkClass]
     Tag() PropertyInterface[string]
@@ -1013,11 +1013,21 @@ func (self *HttpExampleOrgLinkClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *HttpExampleOrgLinkClassObject) Extensible() RefPropertyInterface[HttpExampleOrgExtensibleClass] { return &self.extensible }
-func (self *HttpExampleOrgLinkClassObject) LinkListProp() ListPropertyInterface[Ref[HttpExampleOrgLinkClass]] { return &self.linkListProp }
-func (self *HttpExampleOrgLinkClassObject) LinkProp() RefPropertyInterface[HttpExampleOrgLinkClass] { return &self.linkProp }
-func (self *HttpExampleOrgLinkClassObject) LinkPropNoClass() RefPropertyInterface[HttpExampleOrgLinkClass] { return &self.linkPropNoClass }
-func (self *HttpExampleOrgLinkClassObject) Tag() PropertyInterface[string] { return &self.tag }
+func (self *HttpExampleOrgLinkClassObject) Extensible() RefPropertyInterface[HttpExampleOrgExtensibleClass] {
+    return &self.extensible
+}
+func (self *HttpExampleOrgLinkClassObject) LinkListProp() RefListPropertyInterface[HttpExampleOrgLinkClass] {
+    return &self.linkListProp
+}
+func (self *HttpExampleOrgLinkClassObject) LinkProp() RefPropertyInterface[HttpExampleOrgLinkClass] {
+    return &self.linkProp
+}
+func (self *HttpExampleOrgLinkClassObject) LinkPropNoClass() RefPropertyInterface[HttpExampleOrgLinkClass] {
+    return &self.linkPropNoClass
+}
+func (self *HttpExampleOrgLinkClassObject) Tag() PropertyInterface[string] {
+    return &self.tag
+}
 
 func (self *HttpExampleOrgLinkClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -1655,7 +1665,9 @@ func (self *HttpExampleOrgRequiredAbstractObject) Link(state *LinkState) error {
 }
 
 
-func (self *HttpExampleOrgRequiredAbstractObject) AbstractClassProp() RefPropertyInterface[HttpExampleOrgAbstractClass] { return &self.abstractClassProp }
+func (self *HttpExampleOrgRequiredAbstractObject) AbstractClassProp() RefPropertyInterface[HttpExampleOrgAbstractClass] {
+    return &self.abstractClassProp
+}
 
 func (self *HttpExampleOrgRequiredAbstractObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -2308,7 +2320,7 @@ type HttpExampleOrgTestClass interface {
     Import() PropertyInterface[string]
     AnyuriProp() PropertyInterface[string]
     BooleanProp() PropertyInterface[bool]
-    ClassListProp() ListPropertyInterface[Ref[HttpExampleOrgTestClass]]
+    ClassListProp() RefListPropertyInterface[HttpExampleOrgTestClass]
     ClassProp() RefPropertyInterface[HttpExampleOrgTestClass]
     ClassPropNoClass() RefPropertyInterface[HttpExampleOrgTestClass]
     DatetimeListProp() ListPropertyInterface[time.Time]
@@ -2622,32 +2634,84 @@ func (self *HttpExampleOrgTestClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *HttpExampleOrgTestClassObject) Encode() PropertyInterface[string] { return &self.encode }
-func (self *HttpExampleOrgTestClassObject) Import() PropertyInterface[string] { return &self.import_ }
-func (self *HttpExampleOrgTestClassObject) AnyuriProp() PropertyInterface[string] { return &self.anyuriProp }
-func (self *HttpExampleOrgTestClassObject) BooleanProp() PropertyInterface[bool] { return &self.booleanProp }
-func (self *HttpExampleOrgTestClassObject) ClassListProp() ListPropertyInterface[Ref[HttpExampleOrgTestClass]] { return &self.classListProp }
-func (self *HttpExampleOrgTestClassObject) ClassProp() RefPropertyInterface[HttpExampleOrgTestClass] { return &self.classProp }
-func (self *HttpExampleOrgTestClassObject) ClassPropNoClass() RefPropertyInterface[HttpExampleOrgTestClass] { return &self.classPropNoClass }
-func (self *HttpExampleOrgTestClassObject) DatetimeListProp() ListPropertyInterface[time.Time] { return &self.datetimeListProp }
-func (self *HttpExampleOrgTestClassObject) DatetimeScalarProp() PropertyInterface[time.Time] { return &self.datetimeScalarProp }
-func (self *HttpExampleOrgTestClassObject) DatetimestampScalarProp() PropertyInterface[time.Time] { return &self.datetimestampScalarProp }
-func (self *HttpExampleOrgTestClassObject) EnumListProp() ListPropertyInterface[string] { return &self.enumListProp }
-func (self *HttpExampleOrgTestClassObject) EnumProp() PropertyInterface[string] { return &self.enumProp }
-func (self *HttpExampleOrgTestClassObject) EnumPropNoClass() PropertyInterface[string] { return &self.enumPropNoClass }
-func (self *HttpExampleOrgTestClassObject) FloatProp() PropertyInterface[float64] { return &self.floatProp }
-func (self *HttpExampleOrgTestClassObject) IntegerProp() PropertyInterface[int] { return &self.integerProp }
-func (self *HttpExampleOrgTestClassObject) NamedProperty() PropertyInterface[string] { return &self.namedProperty }
-func (self *HttpExampleOrgTestClassObject) NonShape() RefPropertyInterface[HttpExampleOrgNonShapeClass] { return &self.nonShape }
-func (self *HttpExampleOrgTestClassObject) NonnegativeIntegerProp() PropertyInterface[int] { return &self.nonnegativeIntegerProp }
-func (self *HttpExampleOrgTestClassObject) PositiveIntegerProp() PropertyInterface[int] { return &self.positiveIntegerProp }
-func (self *HttpExampleOrgTestClassObject) Regex() PropertyInterface[string] { return &self.regex }
-func (self *HttpExampleOrgTestClassObject) RegexDatetime() PropertyInterface[time.Time] { return &self.regexDatetime }
-func (self *HttpExampleOrgTestClassObject) RegexDatetimestamp() PropertyInterface[time.Time] { return &self.regexDatetimestamp }
-func (self *HttpExampleOrgTestClassObject) RegexList() ListPropertyInterface[string] { return &self.regexList }
-func (self *HttpExampleOrgTestClassObject) StringListNoDatatype() ListPropertyInterface[string] { return &self.stringListNoDatatype }
-func (self *HttpExampleOrgTestClassObject) StringListProp() ListPropertyInterface[string] { return &self.stringListProp }
-func (self *HttpExampleOrgTestClassObject) StringScalarProp() PropertyInterface[string] { return &self.stringScalarProp }
+func (self *HttpExampleOrgTestClassObject) Encode() PropertyInterface[string] {
+    return &self.encode
+}
+func (self *HttpExampleOrgTestClassObject) Import() PropertyInterface[string] {
+    return &self.import_
+}
+func (self *HttpExampleOrgTestClassObject) AnyuriProp() PropertyInterface[string] {
+    return &self.anyuriProp
+}
+func (self *HttpExampleOrgTestClassObject) BooleanProp() PropertyInterface[bool] {
+    return &self.booleanProp
+}
+func (self *HttpExampleOrgTestClassObject) ClassListProp() RefListPropertyInterface[HttpExampleOrgTestClass] {
+    return &self.classListProp
+}
+func (self *HttpExampleOrgTestClassObject) ClassProp() RefPropertyInterface[HttpExampleOrgTestClass] {
+    return &self.classProp
+}
+func (self *HttpExampleOrgTestClassObject) ClassPropNoClass() RefPropertyInterface[HttpExampleOrgTestClass] {
+    return &self.classPropNoClass
+}
+func (self *HttpExampleOrgTestClassObject) DatetimeListProp() ListPropertyInterface[time.Time] {
+    return &self.datetimeListProp
+}
+func (self *HttpExampleOrgTestClassObject) DatetimeScalarProp() PropertyInterface[time.Time] {
+    return &self.datetimeScalarProp
+}
+func (self *HttpExampleOrgTestClassObject) DatetimestampScalarProp() PropertyInterface[time.Time] {
+    return &self.datetimestampScalarProp
+}
+func (self *HttpExampleOrgTestClassObject) EnumListProp() ListPropertyInterface[string] {
+    return &self.enumListProp
+}
+func (self *HttpExampleOrgTestClassObject) EnumProp() PropertyInterface[string] {
+    return &self.enumProp
+}
+func (self *HttpExampleOrgTestClassObject) EnumPropNoClass() PropertyInterface[string] {
+    return &self.enumPropNoClass
+}
+func (self *HttpExampleOrgTestClassObject) FloatProp() PropertyInterface[float64] {
+    return &self.floatProp
+}
+func (self *HttpExampleOrgTestClassObject) IntegerProp() PropertyInterface[int] {
+    return &self.integerProp
+}
+func (self *HttpExampleOrgTestClassObject) NamedProperty() PropertyInterface[string] {
+    return &self.namedProperty
+}
+func (self *HttpExampleOrgTestClassObject) NonShape() RefPropertyInterface[HttpExampleOrgNonShapeClass] {
+    return &self.nonShape
+}
+func (self *HttpExampleOrgTestClassObject) NonnegativeIntegerProp() PropertyInterface[int] {
+    return &self.nonnegativeIntegerProp
+}
+func (self *HttpExampleOrgTestClassObject) PositiveIntegerProp() PropertyInterface[int] {
+    return &self.positiveIntegerProp
+}
+func (self *HttpExampleOrgTestClassObject) Regex() PropertyInterface[string] {
+    return &self.regex
+}
+func (self *HttpExampleOrgTestClassObject) RegexDatetime() PropertyInterface[time.Time] {
+    return &self.regexDatetime
+}
+func (self *HttpExampleOrgTestClassObject) RegexDatetimestamp() PropertyInterface[time.Time] {
+    return &self.regexDatetimestamp
+}
+func (self *HttpExampleOrgTestClassObject) RegexList() ListPropertyInterface[string] {
+    return &self.regexList
+}
+func (self *HttpExampleOrgTestClassObject) StringListNoDatatype() ListPropertyInterface[string] {
+    return &self.stringListNoDatatype
+}
+func (self *HttpExampleOrgTestClassObject) StringListProp() ListPropertyInterface[string] {
+    return &self.stringListProp
+}
+func (self *HttpExampleOrgTestClassObject) StringScalarProp() PropertyInterface[string] {
+    return &self.stringScalarProp
+}
 
 func (self *HttpExampleOrgTestClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.HttpExampleOrgParentClassObject.EncodeProperties(data, path, state); err != nil {
@@ -2991,8 +3055,12 @@ func (self *HttpExampleOrgTestClassRequiredObject) Link(state *LinkState) error 
 }
 
 
-func (self *HttpExampleOrgTestClassRequiredObject) RequiredStringListProp() ListPropertyInterface[string] { return &self.requiredStringListProp }
-func (self *HttpExampleOrgTestClassRequiredObject) RequiredStringScalarProp() PropertyInterface[string] { return &self.requiredStringScalarProp }
+func (self *HttpExampleOrgTestClassRequiredObject) RequiredStringListProp() ListPropertyInterface[string] {
+    return &self.requiredStringListProp
+}
+func (self *HttpExampleOrgTestClassRequiredObject) RequiredStringScalarProp() PropertyInterface[string] {
+    return &self.requiredStringScalarProp
+}
 
 func (self *HttpExampleOrgTestClassRequiredObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.HttpExampleOrgTestClassObject.EncodeProperties(data, path, state); err != nil {
@@ -3117,7 +3185,9 @@ func (self *HttpExampleOrgTestDerivedClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *HttpExampleOrgTestDerivedClassObject) StringProp() PropertyInterface[string] { return &self.stringProp }
+func (self *HttpExampleOrgTestDerivedClassObject) StringProp() PropertyInterface[string] {
+    return &self.stringProp
+}
 
 func (self *HttpExampleOrgTestDerivedClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.HttpExampleOrgTestClassObject.EncodeProperties(data, path, state); err != nil {
@@ -3241,7 +3311,9 @@ func (self *HttpExampleOrgUsesExtensibleAbstractClassObject) Link(state *LinkSta
 }
 
 
-func (self *HttpExampleOrgUsesExtensibleAbstractClassObject) Prop() RefPropertyInterface[HttpExampleOrgExtensibleAbstractClass] { return &self.prop }
+func (self *HttpExampleOrgUsesExtensibleAbstractClassObject) Prop() RefPropertyInterface[HttpExampleOrgExtensibleAbstractClass] {
+    return &self.prop
+}
 
 func (self *HttpExampleOrgUsesExtensibleAbstractClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.SHACLObjectBase.EncodeProperties(data, path, state); err != nil {
@@ -3557,8 +3629,12 @@ func (self *HttpExampleOrgExtensibleClassObject) Link(state *LinkState) error {
 }
 
 
-func (self *HttpExampleOrgExtensibleClassObject) Property() PropertyInterface[string] { return &self.property }
-func (self *HttpExampleOrgExtensibleClassObject) Required() PropertyInterface[string] { return &self.required }
+func (self *HttpExampleOrgExtensibleClassObject) Property() PropertyInterface[string] {
+    return &self.property
+}
+func (self *HttpExampleOrgExtensibleClassObject) Required() PropertyInterface[string] {
+    return &self.required
+}
 
 func (self *HttpExampleOrgExtensibleClassObject) EncodeProperties(data map[string]interface{}, path Path, state *EncodeState) error {
     if err := self.HttpExampleOrgLinkClassObject.EncodeProperties(data, path, state); err != nil {

--- a/tests/expect/golang/nocontext/test/reflistproperty.go
+++ b/tests/expect/golang/nocontext/test/reflistproperty.go
@@ -6,6 +6,12 @@
 
 package model
 
+type RefListPropertyInterface[T SHACLObject] interface {
+    ListPropertyInterface[Ref[T]]
+    AppendObj(obj T) error
+    AppendIRI(iri string) error
+}
+
 type RefListProperty[T SHACLObject] struct {
     ListProperty[Ref[T]]
 }
@@ -40,3 +46,14 @@ func (self *RefListProperty[T]) Link(state *LinkState) error {
     }
     return nil
 }
+
+func (self *RefListProperty[T]) AppendObj(obj T) error {
+    // Shorthand to append an object by making a reference to it
+    return self.Append(MakeObjectRef(obj))
+}
+
+func (self *RefListProperty[T]) AppendIRI(iri string) error {
+    // Shorthand to append an IRI by making a reference to it
+    return self.Append(MakeIRIRef[T](iri))
+}
+

--- a/tests/expect/golang/nocontext/test/shaclobjectset.go
+++ b/tests/expect/golang/nocontext/test/shaclobjectset.go
@@ -194,7 +194,8 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
             continue
         }
 
-        o.ID().Set(fmt.Sprintf("_:%d", blank_count))
+
+        o.ID().Set(fmt.Sprintf("_:%s%d", o.GetType().GetCompactTypeIRI().GetDefault(""), blank_count))
         blank_count += 1
         top_objects[o] = true
     }

--- a/tests/expect/golang/nocontext/test/shaclobjectset.go
+++ b/tests/expect/golang/nocontext/test/shaclobjectset.go
@@ -9,6 +9,7 @@ package model
 import (
     "encoding/json"
     "fmt"
+    "sort"
 )
 
 type SHACLObjectSet interface {
@@ -25,6 +26,46 @@ type SHACLObjectSet interface {
 type SHACLObjectSetObject struct {
     objects []SHACLObject
     missingIDs map[string]bool
+}
+
+
+type shaclObjectList struct {
+    v []SHACLObject
+    idx map[SHACLObject]int
+}
+
+func makeshaclObjectList(lst []SHACLObject) shaclObjectList {
+    idx := make(map[SHACLObject]int)
+    for i, o := range lst {
+        idx[o] = i
+    }
+
+    return shaclObjectList{lst, idx}
+}
+
+func (v shaclObjectList) Len() int {
+    return len(v.v)
+}
+
+func (v shaclObjectList) Swap(i, j int) {
+    v.v[i], v.v[j] = v.v[j], v.v[i]
+}
+
+func (v shaclObjectList) Less(i, j int) bool {
+    if v.v[i].ID().IsSet() {
+        if v.v[j].ID().IsSet() {
+            return v.v[i].ID().Get() < v.v[j].ID().Get()
+        } else {
+            return false;
+        }
+    } else {
+        if v.v[j].ID().IsSet() {
+            return true
+        } else {
+            // Neither has an ID. Preserve original insertion order
+            return v.idx[v.v[i]] < v.idx[v.v[j]]
+        }
+    }
 }
 
 func (self *SHACLObjectSetObject) Objects(yield func(SHACLObject) bool) {
@@ -119,6 +160,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
     }
 
     ref_counts := make(map[SHACLObject]int)
+    top_objects := make(map[SHACLObject]bool)
 
     // Count references
     self.Walk(func (path Path, v any) {
@@ -141,6 +183,7 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
         ref_counts[o] = ref_counts[o] + 1
     })
 
+    // Assign blank nodes to objects that have more than one reference
     blank_count := 0
     for o, count := range ref_counts {
         if count <= 1 {
@@ -153,25 +196,38 @@ func (self *SHACLObjectSetObject) Encode(encoder *json.Encoder) error {
 
         o.ID().Set(fmt.Sprintf("_:%d", blank_count))
         blank_count += 1
+        top_objects[o] = true
     }
 
-    if len(self.objects) == 1 {
-        err := self.objects[0].EncodeProperties(data, path, &state)
+    for _, o := range self.objects {
+        top_objects[o] = true
+    }
+
+    // Convert to a list and sort
+    top_list := []SHACLObject{}
+    for o, _ := range top_objects {
+        top_list = append(top_list, o)
+    }
+
+    sort.Sort(makeshaclObjectList(top_list))
+
+    if len(top_list) == 1 {
+        err := top_list[0].EncodeProperties(data, path, &state)
         if err != nil {
             return err
         }
-    } else if len(self.objects) > 1 {
+    } else if len(top_objects) > 1 {
         // All objects directly added to the object set should be written as
         // top level objects, so mark then as written until they are ready to
         // be serialized, which will force them to be referenced by IRI until
         // we are ready
-        for _, o := range self.objects {
+        for _, o := range top_list {
             state.Written[o] = true
         }
 
         graph_path := path.PushPath("@graph")
         lst := []interface{}{}
-        for idx, o := range self.objects {
+        for idx, o := range top_list {
             // Remove this object from the written set now so it gets serialized
             delete(state.Written, o)
 


### PR DESCRIPTION
Makes a few improvement to golang bindings. Notably:

* Shorthand for adding an object or IRI to a List of references
* Any object that is referenced more than once will be serialized in the top level `@graph` (to match the other bindings)
* Blank nodes IDs now include the compact type name (if any)