### PR TITLE
Fix typos in README and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Convert SHACL Model to code bindings
+
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9999/badge)](https://www.bestpractices.dev/projects/9999)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/JPEWdev/shacl2code/badge)](https://scorecard.dev/viewer/?uri=github.com/JPEWdev/shacl2code)
 [![Coverage Report](https://raw.githubusercontent.com/JPEWdev/shacl2code/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/JPEWdev/shacl2code/blob/python-coverage-comment-action-data/htmlcov/index.html)
@@ -16,24 +17,31 @@ python3 -m pip install shacl2code
 ## Usage
 
 `shacl2code` can generate bindings from either a local file:
+
 ```shell
 shacl2code generate -i model.jsonld python -o out.py
 ```
+
 Or from a URL:
+
 ```shell
 shacl2code generate -i https://example.com/rdf/model.jsonld python -o out.py
 ```
+
 Or from stdin:
+
 ```shell
 cat model.jsonld | shacl2code generate -i - python -o - > out.py
 ```
 
 For more information, run:
+
 ```shell
 shacl2code --help
 ```
 
 The available language bindings can be viewed by running:
+
 ```shell
 shacl2code list
 ```
@@ -54,13 +62,13 @@ pip install -e ".[dev]"
 
 `shacl2code` has a test suite written in [pytest][pytest]. To run it, setup a
 virtual environment as shown above, then run:
+
 ```shell
 pytest
 ```
 
 In addition to the test results, a test coverage report will also be generated
 using [pytest-cov][pytest-cov]
-
 
 ## Custom Annotations
 
@@ -90,6 +98,7 @@ turtle will use `MyId` instead of `@id` when writing JSON-LD bindings:
 ```
 
 When doing this, the class would then look like this in JSON-LD:
+
 ```json
 {
     "@type": "MyClass",
@@ -97,7 +106,7 @@ When doing this, the class would then look like this in JSON-LD:
 }
 ```
 
-The `idProperyName` annotation is inherited by derived classes, so for example
+The `idPropertyName` annotation is inherited by derived classes, so for example
 any class that derived from `MyClass` would also use `MyId` as the subject
 property.
 
@@ -129,7 +138,6 @@ indicates if a class can be extended, and defaults to `false`. For example, the
 following turtle will declare a class as extensible:
 
 ```ttl
-
 <MyClass> a owl:Class, sh:NodeShape ;
     sh-to-code:isExtensible true
     .
@@ -165,14 +173,12 @@ a constraint on the shape that it cannot be of its own type. This can be done
 with the following turtle:
 
 ```ttl
-
 <MyClass> a owl:Class, sh:NodeShape ;
-    # SHACL to prevent a class from being instansiated as this exact type
+    # SHACL to prevent a class from being instantiated as this exact type
     sh:property [
         sh:path rdf:type ;
         sh:not [ sh:hasValue <MyClass> ]
     ] .
-
 ```
 
 `shacl2code` will detect this pattern and generate abstract bindings for
@@ -188,7 +194,6 @@ abstract. This can be done with the boolean `isAbstract` property. For
 example, the following turtle will declare a class as abstract:
 
 ```ttl
-
 <MyClass> a owl:Class, sh:NodeShape ;
     sh-to-code:isAbstract true
     .

--- a/src/shacl2code/lang/templates/cpp/errorhandler.cpp.j2
+++ b/src/shacl2code/lang/templates/cpp/errorhandler.cpp.j2
@@ -25,7 +25,7 @@ namespace {{ n }} {
 
 using std::string_literals::operator""s;
 
-// DefaultErrorHanlder
+// DefaultErrorHandler
 DefaultErrorHandler::DefaultErrorHandler() {}
 DefaultErrorHandler::~DefaultErrorHandler() {}
 
@@ -41,7 +41,7 @@ void DefaultErrorHandler::handleDeserializeError(std::string const& message,
 
 DefaultErrorHandler DefaultErrorHandler::handler;
 
-// NoopErrorHanlder
+// NoopErrorHandler
 NoopErrorHandler::NoopErrorHandler() {}
 NoopErrorHandler::~NoopErrorHandler() {}
 

--- a/src/shacl2code/lang/templates/cpp/extensible.hpp.j2
+++ b/src/shacl2code/lang/templates/cpp/extensible.hpp.j2
@@ -40,7 +40,7 @@ typedef std::variant<std::string, int, double, DateTime, Ref<SHACLObject>>
  *
  * Implements the extra APIs that need to be called by an extensible class
  *
- * @note This should not be used directy; instead the SHACLExtensibleObject
+ * @note This should not be used directly; instead the SHACLExtensibleObject
  * template class should be used
  */
 class EXPORT SHACLExtensibleObjectBase {

--- a/src/shacl2code/lang/templates/cpp/object.hpp.j2
+++ b/src/shacl2code/lang/templates/cpp/object.hpp.j2
@@ -60,7 +60,7 @@ class EXPORT SHACLObject {
     };
 
    public:
-    /// Alias for the parameter that desribes the type IRIs an object can have
+    /// Alias for the parameter that describes the type IRIs an object can have
     using TypeIRIs =
         std::optional<std::pair<std::string, std::optional<std::string>>>;
 

--- a/src/shacl2code/lang/templates/cpp/objectpath.cpp.j2
+++ b/src/shacl2code/lang/templates/cpp/objectpath.cpp.j2
@@ -34,7 +34,7 @@ using std::string_literals::operator""s;
  */
 class Finally {
    public:
-    /// Contructor
+    /// Constructor
     explicit Finally(std::function<void(void)>&& func)
         : mFunc(std::move(func)) {}
 

--- a/tests/test_common_jinja.py
+++ b/tests/test_common_jinja.py
@@ -42,7 +42,7 @@ def test_jinja_abort(tmp_path):
 
 def test_bad_id_get(tmp_path):
     """
-    Tests that getting an ID that doens't exists fails
+    Tests that getting an ID that doesn't exists fails
     """
     outfile = tmp_path / "out.txt"
     p = subprocess.run(

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -701,7 +701,7 @@ def test_class_prop_validation(compile_test, prop, value, expect):
         ("test_class", "test_another_class", Progress.COMPILE_FAILS),
     ],
 )
-def test_ref_implict_cast(compile_test, A, B, progress):
+def test_ref_implicit_cast(compile_test, A, B, progress):
     # Check types are valid
     compile_test(
         f"""\
@@ -781,7 +781,7 @@ def test_ref_prop_assignment(compile_test):
     assert output.rstrip() == "_:foo"
 
 
-def test_ref_implict_cast_to_abstract(compile_test):
+def test_ref_implicit_cast_to_abstract(compile_test):
     output = compile_test(
         """\
         auto r = make_obj<concrete_class>();
@@ -807,7 +807,7 @@ def test_ref_implict_cast_to_abstract(compile_test):
 @pytest.mark.parametrize(
     "A,B,progress",
     [
-        # Explict cast to parent class
+        # Explicit cast to parent class
         ("test_class", "parent_class", Progress.RUNS),
         # Explicit cast to self
         ("test_class", "test_class", Progress.RUNS),
@@ -913,7 +913,7 @@ def test_ref_explicit_cast_to_derived(compile_test):
     assert output.rstrip() == "_:foo"
 
 
-def test_ref_explict_cast_to_abstract(compile_test):
+def test_ref_explicit_cast_to_abstract(compile_test):
     output = compile_test(
         """\
         auto r = make_obj<concrete_class>();

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -492,7 +492,7 @@ def type_tests(name, *typ):
 @pytest.mark.parametrize(
     "prop,value,expect",
     [
-        # postive integer
+        # positive integer
         ("test_class_positive_integer_prop", -1, ValueError),
         ("test_class_positive_integer_prop", 0, ValueError),
         ("test_class_positive_integer_prop", 1, 1),
@@ -535,13 +535,13 @@ def type_tests(name, *typ):
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=TEST_TZ),
         ),
         (
-            # Explict timezone
+            # Explicit timezone
             "test_class_datetime_scalar_prop",
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=timezone(-timedelta(hours=6))),
             SAME_AS_VALUE,
         ),
         (
-            # Explict timezone
+            # Explicit timezone
             "test_class_datetime_scalar_prop",
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=timezone(timedelta(hours=0))),
             SAME_AS_VALUE,
@@ -591,13 +591,13 @@ def type_tests(name, *typ):
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=TEST_TZ),
         ),
         (
-            # Explict timezone
+            # Explicit timezone
             "test_class_datetimestamp_scalar_prop",
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=timezone(-timedelta(hours=6))),
             SAME_AS_VALUE,
         ),
         (
-            # Explict timezone
+            # Explicit timezone
             "test_class_datetimestamp_scalar_prop",
             datetime(2024, 3, 11, 0, 0, 0, tzinfo=timezone(timedelta(hours=0))),
             SAME_AS_VALUE,
@@ -1270,7 +1270,7 @@ def test_enum_named_individuals(model):
 
 def test_mandatory_properties(model, tmp_path):
     """
-    Tests that property ordinality (e.g. min count & max count) is checked when
+    Tests that property cardinality (e.g. min count & max count) is checked when
     writing out a file
     """
     s = model.JSONLDSerializer()
@@ -1515,7 +1515,7 @@ def test_required_abstract_class_property(model, tmp_path):
     objset.add(c)
     s = model.JSONLDSerializer()
 
-    # Atempting to serialize without assigning the property should fail
+    # Attempting to serialize without assigning the property should fail
     with outfile.open("wb") as f:
         with pytest.raises(ValueError):
             s.write(objset, f, indent=4)


### PR DESCRIPTION
Also fix minor Markdown lint warnings on a blank line before code blocks.

Replace #38