### PR TITLE
python: Do not initialize object properties

### DIFF
--- a/src/shacl2code/lang/common.py
+++ b/src/shacl2code/lang/common.py
@@ -88,8 +88,6 @@ class JinjaTemplateRender(object):
                 raise KeyError(f"Object with ID {_id} not found")
 
         def get_all_derived(cls):
-            nonlocal classes
-
             def _recurse(cls):
                 result = set(cls.derived_ids)
                 for r in cls.derived_ids:

--- a/src/shacl2code/lang/lang.py
+++ b/src/shacl2code/lang/lang.py
@@ -12,7 +12,6 @@ TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 def language(name):
     def inner(cls):
-        global LANGUAGES
         LANGUAGES[name] = cls
         return cls
 

--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -253,11 +253,6 @@ class ObjectProp(IRIProp):
         self.cls = cls
         self.required = required
 
-    def init(self):
-        if self.required and not self.cls.IS_ABSTRACT:
-            return self.cls()
-        return None
-
     def validate(self, value):
         check_type(value, (self.cls, str))
 

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -131,8 +131,6 @@ class Model(object):
             return default
 
         def set_prop_range(p, range_id):
-            nonlocal class_iris
-
             if range_id in class_iris:
                 p.class_id = str(range_id)
                 return True

--- a/tests/test_model_source.py
+++ b/tests/test_model_source.py
@@ -390,8 +390,6 @@ def test_context_contents():
         context = json.load(f)
 
     def check_prefix(iri, typ):
-        nonlocal context
-
         test_prefix = context["@context"]["test"]
 
         assert iri.startswith(
@@ -403,8 +401,6 @@ def test_context_contents():
         return name
 
     def check_subject(iri, typ):
-        nonlocal context
-
         name = check_prefix(iri, typ)
 
         assert name in context["@context"], f"{typ} '{name}' missing from context"


### PR DESCRIPTION
Do not initialize object properties with a blank instance of the object. In most (or all cases), doing this is more confusing than requiring the user to create an object for the property. This also matches the behavior of the other language bindings