### PR TITLE
Python: Add VALID_TYPES to class Property

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -18,11 +18,10 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any
 
 
 def check_type(obj, types):
-    if not isinstance(obj, types):
+    if types and not isinstance(obj, types):
         if isinstance(types, (list, tuple)):
             raise TypeError(
                 f"Value must be one of type: {', '.join(t.__name__ for t in types)}. Got {type(obj)}"
@@ -36,7 +35,7 @@ class Property(ABC):
     class
     """
 
-    VALID_TYPES = Any
+    VALID_TYPES = ()
 
     def __init__(self, *, pattern=None):
         self.pattern = pattern

--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -35,7 +35,7 @@ class Property(ABC):
     class
     """
 
-    VALID_TYPES = ()
+    VALID_TYPES = ()  # if empty, everything is valid
 
     def __init__(self, *, pattern=None):
         self.pattern = pattern

--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -14,10 +14,11 @@ import sys
 import threading
 import time
 import warnings
-from contextlib import contextmanager
-from datetime import datetime, timezone, timedelta
-from enum import Enum
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
 
 
 def check_type(obj, types):
@@ -34,6 +35,8 @@ class Property(ABC):
     A generic SHACL object property. The different types will derive from this
     class
     """
+
+    VALID_TYPES = Any
 
     def __init__(self, *, pattern=None):
         self.pattern = pattern


### PR DESCRIPTION
To fix Pylint E1101:no-member warning in the resulting Python code that comes from this line in the template:

https://github.com/JPEWdev/shacl2code/blob/b9246b21c1621d078ea1f65ee11c438e28ca5038/src/shacl2code/lang/templates/python.j2#L44-L45

Without the VALID_TYPES declared in the `Property` class, Pylint will warn:

> Instance of 'Property' has no 'VALID_TYPES' member


To fix that, an empty `VALID_TYPES = ()` is added.

In `check_type()`, the argument `types` will then be checked first if it is empty.

If `types` is empty, then the rest of `check_type()` will be skipped.

Note that this PR has changed the semantic of an empty VALID_TYPES. Previously, if VALID_TYPES happens to be empty, it means "nothing is valid". With this PR, it means "everything is valid" (or "nothing to validate").

--

Also sort the imports.