### PR TITLE
Update license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -23,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
+license = "MIT"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Using license classifiers is deprecated. https://peps.python.org/pep-0639/#deprecate-license-classifiers
- Use license key (a valid SPDX license expression) in the [project] instead https://peps.python.org/pep-0639/#add-string-value-to-license-key