### PR TITLE
template/python.j2: Allow to remove object from object set

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -1188,6 +1188,19 @@ class SHACLObjectSet(object):
             self.add_index(obj)
         return obj
 
+    def remove(self, obj: SHACLObject) -> None:
+        """
+        Remove object from object set
+
+        Remove a SHACLObject from the object set and rebuild index.
+        """
+        if not isinstance(obj, SHACLObject):
+            raise TypeError("Object is not of type SHACLObject")
+
+        if obj in self.objects:
+            self.objects.remove(obj)
+            self.create_index()
+
     def update(self, *others) -> None:
         """
         Update object set adding all objects in each other iterable


### PR DESCRIPTION
For simplicity, rebuild the index from scratch instead of trying to remove the object from the index.

But maybe we should try to be clever, and only update the index without rebuilding it.