### PR TITLE
`type` -> `Type`, keep Python 3.8 support

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -1281,9 +1281,13 @@ class SHACLObjectSet(object):
                 yield child
 
     @overload
-    def foreach_type(self, typ: str, *, match_subclass: bool = True) -> Iterator[SHACLObject]: ...
+    def foreach_type(
+        self, typ: str, *, match_subclass: bool = True
+    ) -> Iterator[SHACLObject]: ...
     @overload
-    def foreach_type(self, typ: Type[T_SHACLObject], *, match_subclass: bool = True) -> Iterator[T_SHACLObject]: ...
+    def foreach_type(
+        self, typ: Type[T_SHACLObject], *, match_subclass: bool = True
+    ) -> Iterator[T_SHACLObject]: ...
 
     def foreach_type(
         self, typ: Union[str, Type[T_SHACLObject]], *, match_subclass: bool = True


### PR DESCRIPTION
- Use `typing.Type[..]` instead of built-in `type[..]`, to keep Python 3.8 support
- Declare overloads to help type checkers and keep typing precision; since `foreach_type` method has two signatures (one takes `str`, another takes `Type[T_SHACLObject]`), without an overload, the type checkers may confused
  - If calls foreach_type("Relationship"), returns `spdx3.SHACLObject` (generic)
  - If calls foreach_type(spdx3.Relationship), returns `spdx3.Relationship` (more specific, use info from TypeVar)
- Use "T_SHACLObject" for typevar name to make the name more connected with SHACLObject (either name has no effect at runtime)