### PR TITLE
model: Allow properties to be split

### DIFF
--- a/tests/data/model/test-context.json
+++ b/tests/data/model/test-context.json
@@ -145,6 +145,10 @@
       "@id": "test:test-class/regex-datetimestamp",
       "@type": "xsd:dateTimeStamp"
     },
+    "test-class/split-string-prop": {
+      "@id": "test:test-class/split-string-prop",
+      "@type": "xsd:string"
+    },
     "link-class-link-prop": {
       "@id": "test:link-class-link-prop",
       "@type": "@id"

--- a/tests/data/model/test.ttl
+++ b/tests/data/model/test.ttl
@@ -163,6 +163,15 @@
         sh:class <non-shape-class> ;
         sh:path <test-class/non-shape> ;
         sh:maxCount 1
+    ],
+    [
+        sh:path <test-class/split-string-prop> ;
+        sh:datatype xsd:string
+    ],
+    [
+        sh:path <test-class/split-string-prop> ;
+        sh:name "split" ;
+        sh:maxCount 1
     ]
     .
 
@@ -326,6 +335,11 @@
 
 <test-class/regex-list> a rdf:Property ;
     rdfs:comment "A regex validated string list" ;
+    rdfs:range xsd:string
+    .
+
+<test-class/split-string-prop> a rdf:Property ;
+    rdfs:comment "A split string property" ;
     rdfs:range xsd:string
     .
 

--- a/tests/data/roundtrip.json
+++ b/tests/data/roundtrip.json
@@ -69,7 +69,8 @@
             "test-class/regex-list": ["foo2", "foo3"],
             "test-class/non-shape": "http://serialize.example.com/non-shape",
             "import": "foo",
-            "encode": "foo"
+            "encode": "foo",
+            "test-class/split-string-prop": "this is split"
         },
         {
             "@id": "http://serialize.example.com/test-derived",


### PR DESCRIPTION
In RDF, the value of an object property is specified using the property path as the triple predicate. This means it's not possible to have multiple properties with the same name (path) in an object, since this would be interpreted as multiple values (e.g. a list) for the same property.

This means that it is valid for a NodeShape to have multiple property definitions for the same path in sh:property. In practice, this means that the object property value must pass validation for all the specified shape properties.

shacl2code didn't handle this previously and assumed that sh:property only contained a single validation for each path and would create code that was incorrect by attempting to create duplicate properties. Fix this so that it correctly handles duplicate paths in the property list and merges them together as best as it can.