### PR TITLE
C++ generator fixes

### DIFF
--- a/src/shacl2code/lang/templates/cpp/encode.hpp.j2
+++ b/src/shacl2code/lang/templates/cpp/encode.hpp.j2
@@ -221,7 +221,7 @@ class EXPORT ValueEncoder : public ElementEncoder {
      * @brief Write IRI
      *
      * Encodes an IRI in the output. Note that the string will be either a
-     * fully qualified IRI or a blank node ID. If "compact` is provided and
+     * fully qualified IRI or a blank node ID. If `compact` is provided and
      * the serialization supports compacted IRIs, it should be preferred to
      * the full IRI
      */
@@ -232,7 +232,7 @@ class EXPORT ValueEncoder : public ElementEncoder {
      * @brief Write enum value IRI
      *
      * Encodes an enum value IRI in the output. Note that the string will be
-     * a fully qualified IRI. If "compact" is provided and the serialization
+     * a fully qualified IRI. If `compact` is provided and the serialization
      * supports compacted IRIs, it should be preferred to the full IRI.
      */
     virtual void writeEnum(std::string const& value,


### PR DESCRIPTION
This PR fixes a number of issues observed when executing the test suite on a
machine using GCC 15 and doxygen 1.15.0:
- **cpp: Add missing include**: `uintptr_t` is defined in `cstdint` which was
  not included so far.
- **cpp: Fix doxygen error**: A typo in the verbatim block delimiter causes
  doxygen to abort generation.
