### PR TITLE
Suppress rdflib and pyshacl warnings to reduce test log noise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ addopts = [
     "--import-mode=importlib",
     "--cov=shacl2code",
 ]
+# Suppress 3rd-party warnings to reduce log noise. Remove after libraries get updated.
+filterwarnings = [
+    "ignore:.*ConjunctiveGraph is deprecated.*:DeprecationWarning",         # From rdflib
+    "ignore:.*Dataset.default_context is deprecated.*:DeprecationWarning",  # From rdflib, pyshacl
+    "ignore:.*Dataset.contexts is deprecated.*:DeprecationWarning",         # From rdflib
+]
 pythonpath = [
     "testfixtures"
 ]


### PR DESCRIPTION
Added `filterwarnings` list to pytest section in pyproject.toml to suppress 3rd-party deprecation warnings.