### PR TITLE
tests: Add context with no @id

### DIFF
--- a/tests/data/model/test-context.json
+++ b/tests/data/model/test-context.json
@@ -207,6 +207,9 @@
     "required-abstract/abstract-class-prop": {
       "@id": "test:required-abstract/abstract-class-prop",
       "@type": "@id"
+    },
+    "no-id": {
+      "@type": "xsd:integer"
     }
   }
 }


### PR DESCRIPTION
Adds a context with no `@id` to exercise that code path.