### PR TITLE
python: Make blank node ID assignment reproducible

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -638,10 +638,18 @@ class SHACLObject(object):
     _OBJ_DEPRECATED: Set[str] = set()
     _NEEDS_REG: bool = True
 
+    # Creation count is a list to ensure that the dictionary entry of the class
+    # doesn't have to be updated on every increment (instead the member is
+    # updated in-place).
+    # Without this optimization incrementing the counter showed a slow down
+    # of approximately 40% in a serialize / deserialize cycle.
+    _creation_count = [0]
+
     # Instance variables
     _id: Optional[str]
     _obj_data: Dict[str, Any]
     _obj_metadata: Dict[str, Any]
+    _creation_id: int
 
     def __init__(self, **kwargs):
         if self._is_abstract():
@@ -656,6 +664,13 @@ class SHACLObject(object):
 
         with register_lock:
             cls = self.__class__
+
+            # Keep track of when this instance was born. This value is used to
+            # ensure deterministic ordering when generating blank node IDs
+            # during serialization.
+            self.__dict__["_creation_id"] = cls._creation_count[0]
+            cls._creation_count[0] += 1
+
             if cls._NEEDS_REG:
                 cls._OBJ_PROPERTIES = {}
                 cls._OBJ_IRIS = {}
@@ -989,7 +1004,7 @@ class SHACLObject(object):
                 obj._id or "",
                 obj.TYPE,
                 getattr(obj, "name", None) or "",
-                id(obj),
+                obj.__dict__["_creation_id"],
             )
 
         return sort_key(self) < sort_key(other)

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -343,16 +343,16 @@ def test_node_kind_blank(model, test_context_url):
     c1._id = "http://example.com/c1"
     c2._id = "http://example.com/c2"
 
-    ref = model.node_kind_blank()
+    ref1 = model.node_kind_blank()
 
     with pytest.raises(ValueError):
-        ref._id = "http://example.com/name"
+        ref1._id = "http://example.com/name"
 
     # Blank node assignment is fine but not preserved when serializing
-    ref._id = "_:blank"
+    ref1._id = "_:blank"
 
     # No blank ID is written out for one reference (inline)
-    c1.link_class_link_prop = ref
+    c1.link_class_link_prop = ref1
     result = s.serialize_data(model.SHACLObjectSet([c1, c2]))
     assert result == {
         "@context": test_context_url,
@@ -372,7 +372,7 @@ def test_node_kind_blank(model, test_context_url):
     }
 
     # Blank node is written out for multiple references
-    c2.link_class_link_prop = ref
+    c2.link_class_link_prop = ref1
     result = s.serialize_data(model.SHACLObjectSet([c1, c2]))
     assert result == {
         "@context": test_context_url,
@@ -395,7 +395,7 @@ def test_node_kind_blank(model, test_context_url):
     }
 
     # Listing in the root graph requires a blank node be written
-    result = s.serialize_data(model.SHACLObjectSet([c1, ref]))
+    result = s.serialize_data(model.SHACLObjectSet([c1, ref1]))
     assert result == {
         "@context": test_context_url,
         "@graph": [
@@ -407,6 +407,35 @@ def test_node_kind_blank(model, test_context_url):
                 "@type": "link-class",
                 "@id": "http://example.com/c1",
                 "link-class-link-prop": "_:node_kind_blank0",
+            },
+        ],
+    }
+
+    # ID assignment to blank nodes is deterministic
+    ref2 = model.node_kind_blank()
+    c2.link_class_link_prop = ref2
+
+    result = s.serialize_data(model.SHACLObjectSet([c1, c2, ref1, ref2]))
+    assert result == {
+        "@context": test_context_url,
+        "@graph": [
+            {
+                "@type": "node-kind-blank",
+                "@id": "_:node_kind_blank0",
+            },
+            {
+                "@type": "node-kind-blank",
+                "@id": "_:node_kind_blank1",
+            },
+            {
+                "@type": "link-class",
+                "@id": "http://example.com/c1",
+                "link-class-link-prop": "_:node_kind_blank0",
+            },
+            {
+                "@type": "link-class",
+                "@id": "http://example.com/c2",
+                "link-class-link-prop": "_:node_kind_blank1",
             },
         ],
     }


### PR DESCRIPTION
The IDs of blank nodes are assigned based on the position of the element
during serialization. However, as a last resort, the ordering function
sorts element based on the `id()` of object. This leads to
non-reproducible ordering across process invocations.

The "best" fix for this would most likely be to define a stable order
over the objects themselves. This however has a number of drawbacks:
* The comparison becomes more expensive as in the worst case all
  properties of an object need to be compared (see below).
* Even when all properties are compared, identical (but in terms of
  serialization distinct) objects,  need to be eliminated during
  serialization which again is relatively expensive.

Instead, this change introduces a creation counter which counts the
number of created objects of a specific type. During construction new
objects are assigned the current ID and the counter is incremented. This
allows relatively cheap deterministic ID assignments as long as the
objects of a document are instantiated in the same order.

The performance impact of this change was benchmarked by loading a Yocto
poky core-image-sato SBOM and serializing it again. Loading the SBOM
created 110596 objects. In this benchmark no signficant performance
impact could be observed (19.78s per iteration with the change, 19.71s
without).

Applying the same benchmark to the solution where all properties of an
object are compared shows a significant increase to 23.35s per iteration
and thus the approach of implementing a stable order solely based on the
object's properties was not investigated further.
