### PR TITLE
python: Fix custom indexes on object properties

### DIFF
--- a/src/shacl2code/lang/templates/python.j2
+++ b/src/shacl2code/lang/templates/python.j2
@@ -908,14 +908,15 @@ class SHACLObject(object):
         if obj.NODE_KIND == NodeKind.IRI and not obj._id:
             raise ValueError("Object is missing required IRI")
 
-        if state.objectset is not None:
-            if obj._id:
-                v = state.objectset.find_by_id(obj._id)
-                if v is not None:
-                    return v
-            state.objectset.add_index(obj)
+        if obj._id:
+            if obj._id in state.read_objs:
+                return state.read_objs[obj._id]
+            state.read_objs[obj._id] = obj
 
         obj._decode_properties(obj_d, state)
+
+        if state.objectset is not None:
+            state.objectset.add_index(obj)
 
         return obj
 
@@ -1493,6 +1494,7 @@ class EncodeState(object):
 class DecodeState(object):
     def __init__(self, objectset):
         self.objectset = objectset
+        self.read_objs: Dict[str, SHACLObject] = {}
 
 
 class Decoder(ABC):


### PR DESCRIPTION
After 38bbc07 ("python: Add RDF serializer and deserializer"), users of the library could no longer create custom indexes based on object properties because the call to add objects to the objectset index was moved before the properties were decoded (which was necessary to prevent infinite recursion when parsing RDF).

To correct this, use a new temporary database of objects by their ID in the decoding state and move the call to add the object to the object set after property decoding.