### PR TITLE
python: Remove unnecessary global/nonlocal

### DIFF
--- a/src/shacl2code/lang/templates/python.py.j2
+++ b/src/shacl2code/lang/templates/python.py.j2
@@ -2421,7 +2421,6 @@ def decode_context(decoder: Decoder, objectset: SHACLObjectSet):
     if decoder.is_list():
         for ctx_d in decoder.read_list():
             _decode_ctx(ctx_d)
-            pass
     else:
         _decode_ctx(decoder)
 


### PR DESCRIPTION
Remove unnecessary `global`/`nonlocal` where the variable is not being assigned locally, to fix F824 Flake8 warning in the generated Python code.