### PR TITLE
python: Output python module

### DIFF
--- a/src/shacl2code/lang/python.py
+++ b/src/shacl2code/lang/python.py
@@ -57,7 +57,10 @@ class PythonRender(JinjaTemplateRender):
     HELP = "Python Language Bindings"
 
     FILES = (
-        "main.py",
+        "__init__.py",
+        "__main__.py",
+        "cmd.py",
+        "model.py",
         "stub.pyi",
     )
 

--- a/src/shacl2code/lang/templates/python/__init__.py.j2
+++ b/src/shacl2code/lang/templates/python/__init__.py.j2
@@ -1,0 +1,8 @@
+#! /usr/bin/env python3
+#
+# {{ disclaimer }}
+#
+# SPDX-License-Identifier: {{ spdx_license }}
+
+from .cmd import main  # noqa: F401
+from .model import *  # noqa: F401, F403

--- a/src/shacl2code/lang/templates/python/__main__.py.j2
+++ b/src/shacl2code/lang/templates/python/__main__.py.j2
@@ -1,0 +1,12 @@
+#! /usr/bin/env python3
+#
+# {{ disclaimer }}
+#
+# SPDX-License-Identifier: {{ spdx_license }}
+
+import sys
+
+from .cmd import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/shacl2code/lang/templates/python/cmd.py.j2
+++ b/src/shacl2code/lang/templates/python/cmd.py.j2
@@ -1,0 +1,75 @@
+#! /usr/bin/env python3
+#
+# {{ disclaimer }}
+#
+# SPDX-License-Identifier: {{ spdx_license }}
+
+import argparse
+from pathlib import Path
+from typing import Any, Iterable, List
+
+from .model import (
+    JSONLDDeserializer,
+    JSONLDSerializer,
+    ListProxy,
+    SHACLObject,
+    SHACLObjectSet,
+)
+
+
+def print_tree(objects: Iterable[SHACLObject], all_fields: bool = False) -> None:
+    """
+    Print object tree
+    """
+    seen = set()
+
+    def callback(value: Any, path: List[str]) -> bool:
+        s = ("  " * (len(path) - 1)) + f"{path[-1]}"
+        if isinstance(value, SHACLObject):
+            s += f" {value} ({id(value)})"
+            is_empty = False
+        elif isinstance(value, ListProxy):
+            is_empty = len(value) == 0
+            if is_empty:
+                s += " []"
+        else:
+            s += f" {value!r}"
+            is_empty = value is None
+
+        if all_fields or not is_empty:
+            print(s)
+
+        if isinstance(value, SHACLObject):
+            if value in seen:
+                return False
+            seen.add(value)
+            return True
+
+        return True
+
+    for o in objects:
+        o.walk(callback)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Python SHACL model test")
+    parser.add_argument("infile", type=Path, help="Input file")
+    parser.add_argument("--print", action="store_true", help="Print object tree")
+    parser.add_argument("--outfile", type=Path, help="Output file")
+
+    args = parser.parse_args()
+
+    objectset = SHACLObjectSet()
+    with args.infile.open("r") as f:
+        d = JSONLDDeserializer()
+        d.read(f, objectset)
+
+    if args.print:
+        print_tree(objectset.objects)
+
+    if args.outfile:
+        with args.outfile.open("wb") as f:
+            s = JSONLDSerializer()
+            s.write(objectset, f)
+
+    return 0

--- a/src/shacl2code/lang/templates/python/model.py.j2
+++ b/src/shacl2code/lang/templates/python/model.py.j2
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Generic, TypeVar, Union, cast, overload
+from typing import Generic, TYPE_CHECKING, TypeVar, Union, cast, overload
 
 if TYPE_CHECKING:
     from typing import (
@@ -2909,40 +2909,6 @@ except ImportError:
     pass
 
 
-def print_tree(objects: Iterable[SHACLObject], all_fields: bool = False) -> None:
-    """
-    Print object tree
-    """
-    seen = set()
-
-    def callback(value: Any, path: List[str]) -> bool:
-        s = ("  " * (len(path) - 1)) + f"{path[-1]}"
-        if isinstance(value, SHACLObject):
-            s += f" {value} ({id(value)})"
-            is_empty = False
-        elif isinstance(value, ListProxy):
-            is_empty = len(value) == 0
-            if is_empty:
-                s += " []"
-        else:
-            s += f" {value!r}"
-            is_empty = value is None
-
-        if all_fields or not is_empty:
-            print(s)
-
-        if isinstance(value, SHACLObject):
-            if value in seen:
-                return False
-            seen.add(value)
-            return True
-
-        return True
-
-    for o in objects:
-        o.walk(callback)
-
-
 # fmt: off
 """Format Guard{{ '"' }}{{ '"' }}{{ '"' }}
 CONTEXT_URLS: List[str] = [
@@ -3059,34 +3025,3 @@ class {{ varname(*class.clsname) }}(
 {% endfor %}
 {{ '"' }}{{ '"' }}{{ '"' }}Format Guard"""
 # fmt: on
-
-
-def main() -> int:
-    import argparse
-    from pathlib import Path
-
-    parser = argparse.ArgumentParser(description="Python SHACL model test")
-    parser.add_argument("infile", type=Path, help="Input file")
-    parser.add_argument("--print", action="store_true", help="Print object tree")
-    parser.add_argument("--outfile", type=Path, help="Output file")
-
-    args = parser.parse_args()
-
-    objectset = SHACLObjectSet()
-    with args.infile.open("r") as f:
-        d = JSONLDDeserializer()
-        d.read(f, objectset)
-
-    if args.print:
-        print_tree(objectset.objects)
-
-    if args.outfile:
-        with args.outfile.open("wb") as f:
-            s = JSONLDSerializer()
-            s.write(objectset, f)
-
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -6,9 +6,11 @@
 import hashlib
 import importlib
 import json
+import os
 import re
 import subprocess
 import sys
+import textwrap
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -72,28 +74,37 @@ def python_model(tmp_path_factory, model_context_url):
         [],
         output_dir,
     )
-    py_file = output_dir / "main.py"
-    py_file.chmod(0o755)
-    yield (output_dir, py_file)
+    yield tmp_directory
 
 
 @pytest.fixture(scope="module")
-def model_script(python_model):
-    _, script = python_model
+def model_script(tmp_path_factory, python_model):
+    tmp_directory = tmp_path_factory.mktemp("pythonmodelscript")
+
+    script = tmp_directory / "script.py"
+    script.write_text(textwrap.dedent(f"""\
+        #! /usr/bin/env python3
+        import sys
+        sys.path.append("{python_model}")
+
+        import model
+
+        sys.exit(model.main())
+        """))
+    script.chmod(0o755)
     yield script
 
 
 @pytest.fixture(scope="function")
 def model(python_model):
-    output_dir, _ = python_model
-
     old_path = sys.path[:]
-    sys.path.append(str(output_dir))
+    sys.path.append(str(python_model))
     try:
-        import main
-
-        importlib.reload(main)
-        yield main
+        # Reload all model modules
+        for m in list(sys.modules):
+            if m == "model" or m.startswith("model."):
+                importlib.reload(sys.modules[m])
+        yield importlib.import_module("model")
     finally:
         sys.path = old_path
 
@@ -110,14 +121,11 @@ class TestOutput:
     Test syntax and formatting of the output file
     """
 
-    def test_output_syntax(self, tmp_path, args):
+    def test_output_syntax(self, model_script, args):
         """
         Checks that the output file is valid python syntax by executing it"
         """
-        output_dir = tmp_path / "output"
-        shacl2code_generate(args, [], output_dir)
-
-        subprocess.run([sys.executable, output_dir / "main.py", "--help"], check=True)
+        subprocess.run([model_script, "--help"], check=True)
 
     def test_trailing_whitespace(self, tmp_path, args):
         """
@@ -126,10 +134,11 @@ class TestOutput:
         output_dir = tmp_path / "output"
         shacl2code_generate(args, [], output_dir)
 
-        for num, line in enumerate((output_dir / "main.py").read_text().splitlines()):
-            assert (
-                re.search(r"\s+$", line) is None
-            ), f"Line {num + 1} has trailing whitespace"
+        for p in output_dir.iterdir():
+            for num, line in enumerate(p.read_text().splitlines()):
+                assert (
+                    re.search(r"\s+$", line) is None
+                ), f"{p}: Line {num + 1} has trailing whitespace"
 
     def test_tabs(self, tmp_path, args):
         """
@@ -138,8 +147,9 @@ class TestOutput:
         output_dir = tmp_path / "output"
         shacl2code_generate(args, [], output_dir)
 
-        for num, line in enumerate((output_dir / "main.py").read_text().splitlines()):
-            assert "\t" not in line, f"Line {num + 1} has tabs"
+        for p in output_dir.iterdir():
+            for num, line in enumerate(p.read_text().splitlines()):
+                assert "\t" not in line, f"{p}: Line {num + 1} has tabs"
 
 
 @pytest.mark.parametrize(
@@ -158,10 +168,10 @@ class TestCheckType:
         """
         Mypy static type checking
         """
-        output_dir = tmp_path / "output"
+        output_dir = tmp_path / "model"
         shacl2code_generate(args, [], output_dir)
         subprocess.run(
-            ["mypy", output_dir / "main.py"],
+            ["mypy"] + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
@@ -170,10 +180,11 @@ class TestCheckType:
         """
         Pyrefly static type checking
         """
-        output_dir = tmp_path / "output"
+        output_dir = tmp_path / "model"
         shacl2code_generate(args, [], output_dir)
         subprocess.run(
-            ["pyrefly", "check", output_dir / "main.py"],
+            ["pyrefly", "check", "--search-path", tmp_path]
+            + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
@@ -182,10 +193,10 @@ class TestCheckType:
         """
         Pyright static type checking
         """
-        output_dir = tmp_path / "output"
+        output_dir = tmp_path / "model"
         shacl2code_generate(args, [], output_dir)
         subprocess.run(
-            ["pyright", output_dir / "main.py"],
+            ["pyright"] + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
@@ -194,15 +205,10 @@ class TestCheckType:
         """
         Flake8 linting
         """
-        output_dir = tmp_path / "output"
+        output_dir = tmp_path / "model"
         shacl2code_generate(args, [], output_dir)
         subprocess.run(
-            [
-                "flake8",
-                "--config",
-                TOP_DIR / ".flake8",
-                output_dir / "main.py",
-            ],
+            ["flake8", "--config", TOP_DIR / ".flake8"] + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
@@ -254,6 +260,30 @@ def test_script_roundtrip(model_script, tmp_path, roundtrip):
     subprocess.run(
         [model_script, roundtrip, "--outfile", outpath],
         check=True,
+    )
+
+    with roundtrip.open("r") as f:
+        expect_data = json.load(f)
+
+    with outpath.open("r") as f:
+        data = json.load(f)
+
+    assert data == expect_data
+
+
+def test_module_roundtrip(python_model, tmp_path, roundtrip):
+    outpath = tmp_path / "out.json"
+
+    env = os.environ.copy()
+
+    env["PYTHONPATH"] = os.pathsep.join(
+        env.get("PYTHONPATH", "").split(os.pathsep) + [str(python_model)]
+    )
+
+    subprocess.run(
+        [sys.executable, "-m", "model", roundtrip, "--outfile", outpath],
+        check=True,
+        env=env,
     )
 
     with roundtrip.open("r") as f:
@@ -1709,20 +1739,20 @@ def test_objset_context(model, context, expanded, compacted):
 
 
 def test_slots(model):
-    assert model._USE_SLOTS
+    assert model.model._USE_SLOTS
 
 
 def test_slots_yes(tmp_path):
     output_dir = tmp_path / "output"
     shacl2code_generate(["--input", TEST_MODEL], ["--use-slots", "yes"], output_dir)
-    text = (output_dir / "main.py").read_text()
+    text = (output_dir / "model.py").read_text()
     assert "_USE_SLOTS = True" in text
 
 
 def test_slots_no(tmp_path):
     output_dir = tmp_path / "output"
     shacl2code_generate(["--input", TEST_MODEL], ["--use-slots", "no"], output_dir)
-    text = (output_dir / "main.py").read_text()
+    text = (output_dir / "model.py").read_text()
     assert "_USE_SLOTS = False" in text
 
 


### PR DESCRIPTION
Extend the python output support to output a complete module definition in the output directory (including an `__init__.py and a __main__.py). This allows the output directory to more easily integrated into other projects in the same way as the single file was done previously.