### PR TITLE
python: Add option to exclude main generation

### DIFF
--- a/src/shacl2code/lang/python.py
+++ b/src/shacl2code/lang/python.py
@@ -58,8 +58,6 @@ class PythonRender(JinjaTemplateRender):
 
     FILES = (
         "__init__.py",
-        "__main__.py",
-        "cmd.py",
         "model.py",
         "stub.pyi",
     )
@@ -68,6 +66,7 @@ class PythonRender(JinjaTemplateRender):
         super().__init__(args)
         self.__output = args.output
         self.__use_slots = args.use_slots
+        self.__include_main = args.include_main == "yes"
 
     @classmethod
     def get_arguments(cls, parser):
@@ -77,6 +76,12 @@ class PythonRender(JinjaTemplateRender):
             type=Path,
             help="Output directory",
             required=True,
+        )
+        parser.add_argument(
+            "--include-main",
+            choices=("yes", "no"),
+            default="yes",
+            help="Generate a main function for the module. Default is '%(default)s'",
         )
         parser.add_argument(
             "--use-slots",
@@ -92,8 +97,15 @@ class PythonRender(JinjaTemplateRender):
         t = TEMPLATE_DIR / "python"
         self.__output.mkdir(parents=True, exist_ok=True)
 
+        def get_file(name):
+            return self.__output / name, t / (name + ".j2"), {}
+
         for s in self.FILES:
-            yield self.__output / s, t / (s + ".j2"), {}
+            yield get_file(s)
+
+        if self.__include_main:
+            yield get_file("cmd.py")
+            yield get_file("__main__.py")
 
     def get_extra_env(self):
         return {
@@ -111,4 +123,5 @@ class PythonRender(JinjaTemplateRender):
             use_slots = False
         return {
             "use_slots": use_slots,
+            "include_main": self.__include_main,
         }

--- a/src/shacl2code/lang/templates/python/__init__.py.j2
+++ b/src/shacl2code/lang/templates/python/__init__.py.j2
@@ -4,5 +4,12 @@
 #
 # SPDX-License-Identifier: {{ spdx_license }}
 
-from .cmd import main  # noqa: F401
 from .model import *  # noqa: F401, F403
+
+# fmt: off
+"""Format Guard{{ '"' }}{{ '"' }}{{ '"' }}
+{%- if include_main %}
+from .cmd import main  # noqa: F401, I100, I202
+{%- endif %}
+{{ '"' }}{{ '"' }}{{ '"' }}Format Guard"""
+# fmt on

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -112,30 +112,46 @@ def model(python_model):
         sys.path = old_path
 
 
-@pytest.mark.parametrize(
-    "args",
+MODEL_TESTS = [
+    "args,python_args",
     [
-        ["--input", TEST_MODEL],
-        ["--input", TEST_MODEL, "--context-url", TEST_CONTEXT, SPDX3_CONTEXT_URL],
+        pytest.param(
+            ["--input", TEST_MODEL],
+            [],
+            id="Model",
+        ),
+        pytest.param(
+            ["--input", TEST_MODEL, "--context-url", TEST_CONTEXT, SPDX3_CONTEXT_URL],
+            [],
+            id="Context URL",
+        ),
+        pytest.param(
+            ["--input", TEST_MODEL],
+            ["--include-main=no"],
+            id="No main",
+        ),
     ],
-)
+]
+
+
+@pytest.mark.parametrize(*MODEL_TESTS)
 class TestOutput:
     """
     Test syntax and formatting of the output file
     """
 
-    def test_output_syntax(self, model_script, args):
+    def test_output_syntax(self, model_script, args, python_args):
         """
         Checks that the output file is valid python syntax by executing it"
         """
         subprocess.run([model_script, "--help"], check=True)
 
-    def test_trailing_whitespace(self, tmp_path, args):
+    def test_trailing_whitespace(self, tmp_path, args, python_args):
         """
         Tests that the generated file does not have trailing whitespace
         """
         output_dir = tmp_path / "output"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
 
         for p in output_dir.iterdir():
             for num, line in enumerate(p.read_text().splitlines()):
@@ -143,48 +159,42 @@ class TestOutput:
                     re.search(r"\s+$", line) is None
                 ), f"{p}: Line {num + 1} has trailing whitespace"
 
-    def test_tabs(self, tmp_path, args):
+    def test_tabs(self, tmp_path, args, python_args):
         """
         Tests that the output file doesn't contain tabs
         """
         output_dir = tmp_path / "output"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
 
         for p in output_dir.iterdir():
             for num, line in enumerate(p.read_text().splitlines()):
                 assert "\t" not in line, f"{p}: Line {num + 1} has tabs"
 
 
-@pytest.mark.parametrize(
-    "args",
-    [
-        ["--input", TEST_MODEL],
-        ["--input", TEST_MODEL, "--context-url", TEST_CONTEXT, SPDX3_CONTEXT_URL],
-    ],
-)
+@pytest.mark.parametrize(*MODEL_TESTS)
 class TestCheckType:
     """
     Static type checking tests for the generated Python code
     """
 
-    def test_mypy(self, tmp_path, args):
+    def test_mypy(self, tmp_path, args, python_args):
         """
         Mypy static type checking
         """
         output_dir = tmp_path / "model"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
         subprocess.run(
             ["mypy"] + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
 
-    def test_pyrefly(self, tmp_path, args):
+    def test_pyrefly(self, tmp_path, args, python_args):
         """
         Pyrefly static type checking
         """
         output_dir = tmp_path / "model"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
         subprocess.run(
             ["pyrefly", "check", "--search-path", tmp_path]
             + list(output_dir.iterdir()),
@@ -192,24 +202,24 @@ class TestCheckType:
             check=True,
         )
 
-    def test_pyright(self, tmp_path, args):
+    def test_pyright(self, tmp_path, args, python_args):
         """
         Pyright static type checking
         """
         output_dir = tmp_path / "model"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
         subprocess.run(
             ["pyright"] + list(output_dir.iterdir()),
             encoding="utf-8",
             check=True,
         )
 
-    def test_flake8(self, tmp_path, args):
+    def test_flake8(self, tmp_path, args, python_args):
         """
         Flake8 linting
         """
         output_dir = tmp_path / "model"
-        shacl2code_generate(args, [], output_dir)
+        shacl2code_generate(args, python_args, output_dir)
         subprocess.run(
             ["flake8", "--config", TOP_DIR / ".flake8"] + list(output_dir.iterdir()),
             encoding="utf-8",


### PR DESCRIPTION
Adds a command line option to exclude the generation of a `__main__.py` and `main()` function when generating python bindings