### PR TITLE
python: Add version option

### DIFF
--- a/src/shacl2code/lang/python.py
+++ b/src/shacl2code/lang/python.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .common import JinjaTemplateRender
 from .lang import TEMPLATE_DIR, language
+from ..util import convert_version_string
 
 DATATYPE_CLASSES = {
     "http://www.w3.org/2001/XMLSchema#string": "StringProp",
@@ -67,6 +68,11 @@ class PythonRender(JinjaTemplateRender):
         self.__output = args.output
         self.__use_slots = args.use_slots
         self.__include_main = args.include_main == "yes"
+        self.__version_str = args.version
+        if args.version:
+            self.__version = repr(convert_version_string(args.version))
+        else:
+            self.__version = ""
 
     @classmethod
     def get_arguments(cls, parser):
@@ -91,6 +97,10 @@ class PythonRender(JinjaTemplateRender):
                 "Use __slot__ to reduce memory usage. "
                 "Slots prevents multiple inheritance. Default is %(default)s"
             ),
+        )
+        parser.add_argument(
+            "--version",
+            help="Specify model version",
         )
 
     def get_outputs(self):
@@ -124,4 +134,6 @@ class PythonRender(JinjaTemplateRender):
         return {
             "use_slots": use_slots,
             "include_main": self.__include_main,
+            "version_str": self.__version_str,
+            "version": self.__version,
         }

--- a/src/shacl2code/lang/templates/python/model.py.j2
+++ b/src/shacl2code/lang/templates/python/model.py.j2
@@ -713,6 +713,11 @@ def is_blank_node(s: Any) -> bool:
 # fmt: off
 """Format Guard{{ '"' }}{{ '"' }}{{ '"' }}
 _USE_SLOTS = {{ use_slots }}
+{% if version_str %}
+VERSION_STRING = "{{ version_str }}"
+{% endif %}{% if version %}
+VERSION = {{ version }}
+{% endif %}
 {{ '"' }}{{ '"' }}{{ '"' }}Format Guard"""
 # fmt: on
 

--- a/src/shacl2code/util.py
+++ b/src/shacl2code/util.py
@@ -1,0 +1,31 @@
+#! /usr/bin/env python3
+#
+# Copyright (c) 2026 Joshua Watt
+#
+# SPDX-License-Identifier: MIT
+
+
+def convert_version_string(s):
+    """
+    Converts a version string into a tuple. The version is split by the "."
+    character, and any part that can be converted to a base-10 positive integer
+    is converted, otherwise it is left as a string.
+    """
+    if not s:
+        return tuple()
+
+    result = []
+    for part in s.split("."):
+        try:
+            if not part.startswith("+"):
+                i = int(part, 10)
+                if i >= 0:
+                    result.append(i)
+                    continue
+
+        except ValueError:
+            pass
+
+        result.append(part)
+
+    return tuple(result)

--- a/tests/test_convert_version_string.py
+++ b/tests/test_convert_version_string.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Joshua Watt
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from shacl2code.util import convert_version_string
+
+
+def p(string, value):
+    return pytest.param(string, value, id=string)
+
+
+@pytest.mark.parametrize(
+    "string,value",
+    [
+        p("1.0.0", (1, 0, 0)),
+        p(".0.0", ("", 0, 0)),
+        p("1", (1,)),
+        p("-1.0.-10", ("-1", 0, "-10")),
+        p("0x01.0.0b11", ("0x01", 0, "0b11")),
+        p("+1.0", ("+1", 0)),
+        p("1.alpha", (1, "alpha")),
+        p("", tuple()),
+        p(".", ("", "")),
+        p("alpha.0", ("alpha", 0)),
+        p("-1suffix", ("-1suffix",)),
+        p("+1suffix", ("+1suffix",)),
+    ],
+)
+def test_convert_version_string(string, value):
+    assert convert_version_string(string) == value

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -38,6 +38,8 @@ SPDX3_CONTEXT_URL = "https://spdx.github.io/spdx-3-model/context.json"
 
 TEST_TZ = timezone(timedelta(hours=-2), name="TST")
 
+MODEL_VERSION = "1.0.0.alpha"
+
 
 def shacl2code_generate(args, python_args, outfile):
     return subprocess.run(
@@ -74,7 +76,10 @@ def python_model(tmp_path_factory, model_context_url):
             "--context",
             model_context_url,
         ],
-        [],
+        [
+            "--version",
+            MODEL_VERSION,
+        ],
         output_dir,
     )
     yield tmp_directory
@@ -130,6 +135,7 @@ MODEL_TESTS = [
             ["--include-main=no"],
             id="No main",
         ),
+        pytest.param(["--input", TEST_MODEL], ["--version=1.0.0"], id="Version"),
     ],
 ]
 
@@ -2014,3 +2020,10 @@ def test_introspection_extensible(model):
     # IRI-keyed extensible properties must NOT appear in dir()
     c["http://example.org/extensible-test-prop"] = "test-value"
     assert "http://example.org/extensible-test-prop" not in dir(c)
+
+
+def test_version(model):
+    from shacl2code.util import convert_version_string
+
+    assert model.VERSION_STRING == MODEL_VERSION
+    assert model.VERSION == convert_version_string(MODEL_VERSION)


### PR DESCRIPTION
Adds the option to specify a version number for the generated bindings. The version will be converted to a integer if possible.