### PR TITLE
Use pytest-xdist to distribute tests to CPUs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pyshacl >= 0.25.0",
     "pytest >= 7.4",
     "pytest-cov >= 4.1",
+    "pytest-xdist >= 3.5",
     "types-jsonschema >= 4.23.0",
 ]
 
@@ -75,6 +76,9 @@ warn_redundant_casts = true
 addopts = [
     "--import-mode=importlib",
     "--cov=shacl2code",
+    "-n",
+    "auto",
+    "--dist=loadfile",
 ]
 # Suppress 3rd-party warnings to reduce log noise. Remove after libraries get updated.
 filterwarnings = [


### PR DESCRIPTION
Add [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) plugin to pytest.

Tests will be distributed to workers. Number of workers depends on number of CPUs.

On GitHub workflow (with 2 CPUs on Ubuntu instance), this reduce time from 9-10 minutes per one test suite to 6-7 minutes.

Works well with pytest-cov. Coverage report does not affect (stay at 100%).