### PR TITLE
Drop support of Python 3.8 + make explicit Black target-versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,8 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.14" # must match the latest in Black's target-version (see: pyproject.toml)
+          # Black in this Python version must support all target-versions listed in pyproject.toml
+          python-version: "3.14"
       - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
       - uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2.3.0
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: "3.14" # must match the latest in Black's target-version (see: pyproject.toml)
       - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e # 26.5.1
       - uses: py-actions/flake8@84ec6726560b6d5bd68f2a5bed83d62b52bb50ba # v2.3.0
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
             python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,5 +95,7 @@ relative_files = true
 patch = ["subprocess"]
 
 [tool.black]
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
+# Note: "py314" can't be used as a target-version because Black 24.8.0 (latest
+# supported version for Python 3.8) doesn't recognize it.
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
 include = '(\.pyi?(\.j2)?$)|(main\.py\.j2$)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,15 @@ license = "MIT"
 dev = [
     "flake8 >= 7.0.0",
     "flake8-import-order >= 0.19.2",
-    "jsonschema >= 4.23.0",  # latest version for Python 3.8 is 4.23.x
-    "mypy >= 1.14.1",  # latest version for Python 3.8 is 1.14.x
+    "jsonschema >= 4.25.1",  # latest version for Python 3.9 is 4.25.x
+    "mypy >= 1.19.1",  # latest version for Python 3.9 is 1.19.x
     "pyrefly >= 0.55.0",
     "pyright >= 1.1.403",
     "pyshacl >= 0.25.0",
     "pytest >= 7.4",
     "pytest-cov >= 4.1",
     "pytest-xdist >= 3.5",
-    "types-jsonschema >= 4.23.0",
+    "types-jsonschema >= 4.25.1",
 ]
 
 [project.urls]
@@ -94,5 +94,5 @@ relative_files = true
 patch = ["subprocess"]
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312", "py313", "py14"]
+target-version = ["py39", "py310", "py311", "py312", "py313", "py314"]
 include = '(\.pyi?(\.j2)?$)|(main\.py\.j2$)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,4 +95,5 @@ relative_files = true
 patch = ["subprocess"]
 
 [tool.black]
+target-version = ["py38", "py39", "py310", "py311", "py312", "py313", "py314"]
 include = '(\.pyi?(\.j2)?$)|(main\.py\.j2$)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = [
     "jinja2 >= 3.1.2",
     "rdflib >= 7.0.0",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [
     {name = "Joshua Watt", email = "JPEWhacker@gmail.com"},
 ]
@@ -16,7 +16,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Build Tools",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -95,7 +94,5 @@ relative_files = true
 patch = ["subprocess"]
 
 [tool.black]
-# Note: "py314" can't be used as a target-version because Black 24.8.0 (latest
-# supported version for Python 3.8) doesn't recognize it.
-target-version = ["py38", "py39", "py310", "py311", "py312", "py313"]
+target-version = ["py39", "py310", "py311", "py312", "py313", "py14"]
 include = '(\.pyi?(\.j2)?$)|(main\.py\.j2$)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ license = "MIT"
 
 [project.optional-dependencies]
 dev = [
+    "black >= 25.11.0",
     "flake8 >= 7.0.0",
     "flake8-import-order >= 0.19.2",
     "jsonschema >= 4.25.1",  # latest version for Python 3.9 is 4.25.x


### PR DESCRIPTION
- Drop end-of-life Python 3.8
- Specify Black's `target-version` to be explicit and defensive