### PR TITLE
README: How to use JSON-LD contexts; Update metavar name in --context help

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,59 @@ The available language bindings can be viewed by running:
 shacl2code list
 ```
 
+### Using JSON-LD contexts
+
+When using JSON-LD contexts, the context document shall align with the model.
+
+During model development, there may be cases where the context URL is known
+but not yet live or resolvable. In these situations, you can use the
+`--context-url` option to map your local context file to its future public home.
+
+The `--context-url` option accepts two arguments:
+
+1. `CONTEXT_LOCATION`: The actual path to the local or temporary file
+   containing the context.
+2. `CONTEXT_URL`: The official public URL. While temporarily unresolvable
+   during development, this is the URL that production JSON-LD processors will
+   eventually rely on, so it must be recorded inside the generated JSON Schema.
+
 ### Generating the JSON Schema file
 
-`shacl2code` can generate a JSON schema with the following command:
+`shacl2code` can generate a JSON Schema directly from a model.
+
+To view all options specific to JSON Schema generation, run:
 
 ```shell
-shacl2code generate -i spdx-model.json-ld -u spdx-context.jsonld https://spdx.org/rdf/3.0.1/spdx-context.jsonld jsonschema -o json-schema-3.0.1.json
+shacl2code generate jsonschema -h
 ```
 
-Note that the spdx-context.jsonld file should match the model described in the spdx-model.json-ld file.
+#### Example 1: Generating from publicly available URLs
+
+To generate a schema using remote, publicly accessible assets
+(such as SPDX 3.0.1):
+
+```shell
+shacl2code generate \
+    --input https://spdx.org/rdf/3.0.1/spdx-model.ttl \
+    --input https://spdx.org/rdf/3.0.1/spdx-json-serialize-annotations.ttl \
+    --context https://spdx.org/rdf/3.0.1/spdx-context.jsonld \
+    jsonschema \
+    --output spdx-json-schema.json
+```
+
+### Example 2: Generating with a local context document
+
+To generate a schema using a local context file while embedding its future
+public URL:
+
+```shell
+shacl2code generate \
+    --input spdx-model.ttl \
+    --input jsonld-annotations.ttl \
+    --context-url spdx-context.jsonld https://spdx.org/rdf/3.1/spdx-context.jsonld \
+    jsonschema \
+   --output spdx-json-schema.json
+```
 
 ## Developing
 

--- a/src/shacl2code/main.py
+++ b/src/shacl2code/main.py
@@ -100,16 +100,17 @@ def main(args=None):
     generate_parser.add_argument(
         "--context",
         "-x",
-        help="Require context for output (URL). Specified multiple times for multiple contexts",
+        help="Require context from CONTEXT_URL. Specified multiple times for multiple contexts",
+        metavar="CONTEXT_URL",
         action="append",
         default=[],
     )
     generate_parser.add_argument(
         "--context-url",
         "-u",
-        help="Require context from LOCATION (path or URL), but report as URL in generated code. Specified multiple times for multiple contexts",
+        help="Require context from CONTEXT_LOCATION (path or URL), but report as CONTEXT_URL in generated code. Specified multiple times for multiple contexts",
         nargs=2,
-        metavar=("LOCATION", "URL"),
+        metavar=("CONTEXT_LOCATION", "CONTEXT_URL"),
         action="append",
         default=[],
     )


### PR DESCRIPTION
- Explain how to use the JSON-LD contexts
- Make two distinct examples between `--context` and `--context-url`
- Add annotation files in the example (from https://github.com/JPEWdev/shacl2code/pull/24#discussion_r1742362491)
- Update variable name in helps of `--context` and `--context-url` to allow user to see connections between the two.

  Currently, `shacl2code generate -h` shows:

  ```text
  --context, -x CONTEXT
                        Require context for output (URL). Specified multiple times for
                        multiple contexts
  --context-url, -u LOCATION URL
                        Require context from LOCATION (path or URL), but report as URL in
                        generated code. Specified multiple times for multiple contexts
  ```

  Which it may not be obvious that `CONTEXT` (of `--context`) and `URL` (of `--context-url`) are the same thing. Also the "LOCATION URL" may be misread together as one parameter.

  With this PR, both `--context` and `--context-url` will use `CONTEXT_URL`, and `CONTEXT_LOCATION` becomes more visible:

  ```text
  --context, -x CONTEXT_URL
                        Require context from CONTEXT_URL. Specified multiple times for
                        multiple contexts
  --context-url, -u CONTEXT_LOCATION CONTEXT_URL
                        Require context from CONTEXT_LOCATION (path or URL), but report
                        as CONTEXT_URL in generated code. Specified multiple times for
                        multiple contexts
  ```
