### PR TITLE
Add ontology and ontology pre-release annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,5 +267,23 @@ classes are automatically concrete unless they indicate otherwise.
 It is also possible to define a class as abstract by declaring it to be of
 type: `http://spdx.invalid./AbstractClass`, but this is not preferred.
 
+### Pre-Release models
+
+`shacl2code` has a custom annotation that can be used to mark an entire
+ontology as "pre-release" meaning it is still subject to break changes. In the
+python bindings, this will cause a `FutureWarning` to be emitted. In order to
+do this, you must declare your ontology, and then use the custom annotation to
+mark it as pre-release:
+
+```ttl
+
+<http://example.org/my-ontology> a ow:Ontology ;
+    sh-to-code:isPreRelease true
+    .
+```
+
+Note that the IRI of the ontology must be the prefix of all IRIs that belong to
+that ontology.
+
 [pytest]: https://www.pytest.org
 [pytest-cov]: https://pytest-cov.readthedocs.io/en/latest/

--- a/src/shacl2code/lang/common.py
+++ b/src/shacl2code/lang/common.py
@@ -119,6 +119,7 @@ class JinjaTemplateRender(object):
             return ni
 
         classes = ObjectList(model.classes)
+        ontologies = ObjectList(model.ontologies)
         concrete_classes = ObjectList(
             list(c for c in model.classes if not c.is_abstract)
         )
@@ -126,6 +127,7 @@ class JinjaTemplateRender(object):
 
         render_args = {
             "classes": classes,
+            "ontologies": ontologies,
             "concrete_classes": concrete_classes,
             "abstract_classes": abstract_classes,
             "context": model.context,

--- a/src/shacl2code/lang/common.py
+++ b/src/shacl2code/lang/common.py
@@ -123,13 +123,11 @@ class JinjaTemplateRender(object):
             list(c for c in model.classes if not c.is_abstract)
         )
         abstract_classes = ObjectList(list(c for c in model.classes if c.is_abstract))
-        enums = ObjectList(model.enums)
 
         render_args = {
             "classes": classes,
             "concrete_classes": concrete_classes,
             "abstract_classes": abstract_classes,
-            "enums": enums,
             "context": model.context,
             **self.get_additional_render_args(model),
         }

--- a/src/shacl2code/lang/templates/python/model.py.j2
+++ b/src/shacl2code/lang/templates/python/model.py.j2
@@ -729,10 +729,23 @@ VERSION = {{ version }}
 _DC_KWARGS = {"slots": True} if _USE_SLOTS and sys.version_info >= (3, 10) else {}
 
 
+__WARNED_ONTOLOGIES: set[str] = set()
+
+
+def _warn_ontology(o: Ontology) -> None:
+    if o.is_prerelease and o.iri not in __WARNED_ONTOLOGIES:
+        warnings.warn(
+            f"Ontology '{o.iri}' is a pre-release version and may change in the future",
+            FutureWarning,
+        )
+        __WARNED_ONTOLOGIES.add(o.iri)
+
+
 @dataclass(**_DC_KWARGS)
 class Ontology:
     iri: str
     version: Optional[str] = None
+    is_prerelease: bool = False
 
 
 @dataclass(**_DC_KWARGS)
@@ -985,6 +998,9 @@ class SHACLObject(metaclass=SHACLObjectMeta):
             warnings.warn(
                 f"{self.__class__.__name__} is deprecated", DeprecationWarning
             )
+
+        if self.ONTOLOGY:
+            _warn_ontology(self.ONTOLOGY)
 
         with register_lock:
             cls = self.__class__
@@ -2976,6 +2992,7 @@ CONTEXT_URLS: List[str] = [
 {% endif %}
 {{ varname(o.name).upper() }} = Ontology(
     iri="{{ o._id }}",
+    is_prerelease={{ o.is_prerelease }},
 {%- if o.version %}
     version="{{ o.version }}",
 {%- endif %}

--- a/src/shacl2code/lang/templates/python/model.py.j2
+++ b/src/shacl2code/lang/templates/python/model.py.j2
@@ -730,6 +730,12 @@ _DC_KWARGS = {"slots": True} if _USE_SLOTS and sys.version_info >= (3, 10) else 
 
 
 @dataclass(**_DC_KWARGS)
+class Ontology:
+    iri: str
+    version: Optional[str] = None
+
+
+@dataclass(**_DC_KWARGS)
 class ClassProp:
     """Descriptor for a single property on a SHACLObject class, holding its IRI, Python name, and constraints."""
 
@@ -1328,6 +1334,7 @@ class SHACLExtensibleObject(SHACLObject):
     """A SHACLObject that accepts and round-trips arbitrary IRI-keyed extension properties."""
 
     CLOSED = False
+    ONTOLOGY: ClassVar[Optional[Ontology]] = None
 
     def __init__(self, typ: Optional[str] = None, **kwargs: Any) -> None:
         self._extensible = {
@@ -2958,6 +2965,22 @@ CONTEXT_URLS: List[str] = [
 {%- endfor %}
 ]
 
+# ONTOLOGIES
+{%- for o in ontologies %}
+{%- if o.comment %}
+{{ '"' }}{{ '"' }}{{ '"' }}
+{%- for l in o.comment.split("\n") %}
+{{ l.rstrip() }}
+{%- endfor %}
+{{ '"' }}{{ '"' }}{{ '"' }}
+{% endif %}
+{{ varname(o.name).upper() }} = Ontology(
+    iri="{{ o._id }}",
+{%- if o.version %}
+    version="{{ o.version }}",
+{%- endif %}
+)
+{% endfor %}
 
 # CLASSES
 {%- for class in classes %}
@@ -2995,6 +3018,7 @@ class {{ varname(*class.clsname) }}(
     {%- if class.deprecated %}
     IS_DEPRECATED: ClassVar[bool] = True
     {%- endif %}
+    ONTOLOGY: ClassVar[Optional[Ontology]] = {% if class.ontology %}{{ varname(class.ontology.name).upper() }}{% else %}None{% endif %}
     {%- if class.named_individuals %}
     NAMED_INDIVIDUALS: ClassVar[Dict[str, str]] = {
         {%- for member in class.named_individuals %}

--- a/src/shacl2code/lang/templates/python/model.pyi.j2
+++ b/src/shacl2code/lang/templates/python/model.pyi.j2
@@ -222,6 +222,14 @@ class NodeKind(Enum):
 
 def is_IRI(s: Any) -> bool: ...
 def is_blank_node(s: Any) -> bool: ...
+
+
+@dataclass
+class Ontology:
+    iri: str
+    version: Optional[str] = ...
+
+
 @dataclass
 class ClassProp:
     pyname: str
@@ -256,6 +264,7 @@ class SHACLObject:
     ID_ALIAS: ClassVar[Optional[str]]
     IS_ABSTRACT: ClassVar[bool]
     IS_DEPRECATED: ClassVar[bool]
+    ONTOLOGY: ClassVar[Optional[Ontology]]
     TYPE: ClassVar[str]
     COMPACT_TYPE: ClassVar[Optional[str]]
     PROPERTIES: ClassVar[List[ClassProp]]
@@ -424,6 +433,7 @@ class {{ varname(*class.clsname) }}(
     {%- if class.deprecated %}
     IS_DEPRECATED: ClassVar[bool]
     {%- endif %}
+    ONTOLOGY: ClassVar[Optional[Ontology]]
     {%- if class.named_individuals %}
     NAMED_INDIVIDUALS: ClassVar[Dict[str, str]]
 

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -345,6 +345,8 @@ class Model(object):
         object with the context applied
         """
         _id = str(_id)
+        if not self.context:
+            return _id
         if _id not in self.compact_ids:
             self.compact_ids[_id] = self.context.compact_iri(_id)
 

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -64,10 +64,20 @@ def remove_common_prefix(val, *cmp):
 
 
 @dataclass
+class Ontology:
+    _id: str
+    name: str
+    comment: str = ""
+    label: str = ""
+    version: str = ""
+
+
+@dataclass
 class Individual:
     _id: str
     varname: str
     comment: str = ""
+    ontology: Optional[Ontology] = None
 
 
 @dataclass
@@ -98,6 +108,7 @@ class Class:
     is_abstract: bool = False
     named_individuals: Optional[List[Individual]] = None
     deprecated: bool = False
+    ontology: Optional[Ontology] = None
 
 
 class Model(object):
@@ -107,6 +118,7 @@ class Model(object):
         self.compact_ids = {}
         self.objects = {}
         self.classes = []
+        self.ontologies = []
         class_iris = set()
         classes_by_iri = {}
 
@@ -119,6 +131,12 @@ class Model(object):
             if v is None:
                 return v
             return str(v)
+
+        def get_ontology(_id):
+            for o in self.ontologies:
+                if str(_id).startswith(o._id):
+                    return o
+            return None
 
         def get_inherited_value(subject, predicate, default=None):
             def get_value(subject, predicate):
@@ -158,6 +176,7 @@ class Model(object):
                         comment=str(
                             self.model.value(member_iri, RDFS.comment, default="")
                         ),
+                        ontology=get_ontology(member_iri),
                     )
                 )
             members.sort(key=lambda i: i._id)
@@ -175,6 +194,17 @@ class Model(object):
                 return True
 
             return False
+
+        for onto_iri in self.model.subjects(RDF.type, OWL.Ontology):
+            label = str(self.model.value(onto_iri, RDFS.label, default=""))
+            o = Ontology(
+                _id=str(onto_iri),
+                name=label or str(onto_iri),
+                label=label,
+                comment=str(self.model.value(onto_iri, RDFS.comment, default="")),
+                version=str(self.model.value(onto_iri, OWL.versionInfo, default="")),
+            )
+            self.ontologies.append(o)
 
         class_iris = set(self.model.subjects(RDF.type, OWL.Class)) | set(
             self.model.subjects(RDF.type, OWL.DeprecatedClass)
@@ -199,6 +229,7 @@ class Model(object):
                 is_abstract=is_abstract(cls_iri),
                 named_individuals=get_named_individuals(cls_iri),
                 deprecated=(cls_iri, RDF.type, OWL.DeprecatedClass) in self.model,
+                ontology=get_ontology(cls_iri),
             )
 
             if c.node_kind not in (SH.IRI, SH.BlankNode, SH.BlankNodeOrIRI):
@@ -289,6 +320,7 @@ class Model(object):
             c.derived_ids.sort()
 
         self.classes.sort(key=lambda c: c._id)
+        self.ontologies.sort(key=lambda o: o._id)
 
         tmp_classes = self.classes
         done_ids = set()

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -106,7 +106,6 @@ class Model(object):
         self.context = context
         self.compact_ids = {}
         self.objects = {}
-        self.enums = []
         self.classes = []
         class_iris = set()
         classes_by_iri = {}
@@ -289,7 +288,6 @@ class Model(object):
         for c in self.classes:
             c.derived_ids.sort()
 
-        self.enums.sort(key=lambda e: e._id)
         self.classes.sort(key=lambda c: c._id)
 
         tmp_classes = self.classes

--- a/src/shacl2code/model.py
+++ b/src/shacl2code/model.py
@@ -31,6 +31,7 @@ class SHACL2CODE(DefinedNamespace):
     idPropertyName: URIRef
     isExtensible: URIRef
     isAbstract: URIRef
+    isPreRelease: URIRef
 
     _NS = Namespace("https://jpewdev.github.io/shacl2code/schema#")
 
@@ -70,6 +71,7 @@ class Ontology:
     comment: str = ""
     label: str = ""
     version: str = ""
+    is_prerelease: bool = False
 
 
 @dataclass
@@ -203,6 +205,9 @@ class Model(object):
                 label=label,
                 comment=str(self.model.value(onto_iri, RDFS.comment, default="")),
                 version=str(self.model.value(onto_iri, OWL.versionInfo, default="")),
+                is_prerelease=bool(
+                    self.model.value(onto_iri, SHACL2CODE.isPreRelease, default=False)
+                ),
             )
             self.ontologies.append(o)
 

--- a/tests/data/bad-node-kind.ttl
+++ b/tests/data/bad-node-kind.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/bad-pattern-class.ttl
+++ b/tests/data/bad-pattern-class.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/bad-pattern-integer.ttl
+++ b/tests/data/bad-pattern-integer.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/bad-prop-type.ttl
+++ b/tests/data/bad-prop-type.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/context.j2
+++ b/tests/data/context.j2
@@ -1,9 +1,6 @@
 {% for url in context.urls -%}
 Context: {{ url }}
 {% endfor -%}
-{% for enum in enums %}
-{{ enum._id }}: {{ context.compact_iri(enum._id) }}
-{% endfor %}
 {% for class in classes %}
 {{ class._id }}: {{ context.compact_iri(class._id) }}
 {% endfor %}

--- a/tests/data/missing-range.ttl
+++ b/tests/data/missing-range.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/model/test-context.json
+++ b/tests/data/model/test-context.json
@@ -1,7 +1,7 @@
 {
   "@context": {
-    "@base": "http://example.org/",
-    "test": "http://example.org/",
+    "@base": "http://example.org/shacl2code-test/",
+    "test": "http://example.org/shacl2code-test/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "aaa-derived-class": "test:aaa-derived-class",
     "abstract-class": "test:abstract-class",

--- a/tests/data/model/test.ttl
+++ b/tests/data/model/test.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .

--- a/tests/data/model/test.ttl
+++ b/tests/data/model/test.ttl
@@ -6,6 +6,12 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh-to-code: <https://jpewdev.github.io/shacl2code/schema#> .
 
+<http://example.org/shacl2code-test> a owl:Ontology ;
+    rdfs:comment "A test ontology" ;
+    rdfs:label "shacl2code-test" ;
+    owl:versionInfo "1.0.0"
+    .
+
 <aaa-derived-class> a sh:NodeShape, owl:Class ;
     rdfs:subClassOf <parent-class> ;
     rdfs:comment "Derived class that sorts before the parent to test ordering"

--- a/tests/data/raw.j2
+++ b/tests/data/raw.j2
@@ -1,3 +1,6 @@
+{% for o in ontologies %}
+{{ o -}}
+{% endfor %}
 {% for class in classes %}
 {{ class -}}
 {% endfor %}

--- a/tests/data/raw.j2
+++ b/tests/data/raw.j2
@@ -1,6 +1,3 @@
-{% for enum in enums %}
-{{ enum -}}
-{% endfor %}
 {% for class in classes %}
 {{ class -}}
 {% endfor %}

--- a/tests/data/reserved-words.ttl
+++ b/tests/data/reserved-words.ttl
@@ -1,4 +1,4 @@
-@base <http://example.org/reserved#> .
+@base <http://example.org/shacl2code-test/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -546,15 +546,19 @@ CPP_STRING_VAL = 'std::string("string")'
         # Enumerated value
         (
             "_test_class_enum_prop",
-            '"http://example.org/enumType/foo"',
-            "http://example.org/enumType/foo",
+            '"http://example.org/shacl2code-test/enumType/foo"',
+            "http://example.org/shacl2code-test/enumType/foo",
         ),
         (
             "_test_class_enum_prop",
-            'std::string("http://example.org/enumType/foo")',
-            "http://example.org/enumType/foo",
+            'std::string("http://example.org/shacl2code-test/enumType/foo")',
+            "http://example.org/shacl2code-test/enumType/foo",
         ),
-        ("_test_class_enum_prop", "enumType::foo", "http://example.org/enumType/foo"),
+        (
+            "_test_class_enum_prop",
+            "enumType::foo",
+            "http://example.org/shacl2code-test/enumType/foo",
+        ),
         ("_test_class_enum_prop", C_STRING_VAL, Progress.VALIDATION_FAILS),
         ("_test_class_enum_prop", CPP_STRING_VAL, Progress.VALIDATION_FAILS),
         ("_test_class_enum_prop", "0", Progress.RUN_FAILS),
@@ -670,7 +674,7 @@ def test_scalar_prop_validation(compile_test, prop, value, expect):
         (
             "_test_class_class_prop",
             "test_class::named",
-            "IRI http://example.org/test-class/named",
+            "IRI http://example.org/shacl2code-test/test-class/named",
         ),
         # Named individual, but wrong type
         (

--- a/tests/test_golang.py
+++ b/tests/test_golang.py
@@ -627,14 +627,14 @@ GO_STRING = '"string"'
         # Enumerated value
         (
             "TestClassEnumProp",
-            '"http://example.org/enumType/foo"',
-            "http://example.org/enumType/foo",
+            '"http://example.org/shacl2code-test/enumType/foo"',
+            "http://example.org/shacl2code-test/enumType/foo",
             [],
         ),
         (
             "TestClassEnumProp",
             "model.EnumTypeFoo",
-            "http://example.org/enumType/foo",
+            "http://example.org/shacl2code-test/enumType/foo",
             [],
         ),
         ("TestClassEnumProp", GO_STRING, Progress.VALIDATION_FAILS, []),
@@ -757,7 +757,7 @@ def test_scalar_prop_validation(compile_test, prop, value, expect, imports):
         (
             "TestClassClassProp",
             "model.MakeIRIRef[model.TestClass](model.TestClassNamed)",
-            "IRI http://example.org/test-class/named",
+            "IRI http://example.org/shacl2code-test/test-class/named",
         ),
         # Self assignment
         (
@@ -849,7 +849,7 @@ def test_ref_prop_validation(compile_test, prop, value, expect):
         (
             "TestClassClassProp",
             "model.TestClassNamed",
-            "IRI http://example.org/test-class/named",
+            "IRI http://example.org/shacl2code-test/test-class/named",
         ),
         # Self assignment by string
         (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Joshua Watt
+#
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+
+import rdflib
+
+import shacl2code.model
+
+THIS_FILE = Path(__file__)
+THIS_DIR = THIS_FILE.parent
+
+
+@pytest.fixture(scope="session")
+def model():
+    g = rdflib.Graph()
+    g.parse(THIS_DIR / "data" / "model" / "test.ttl")
+    return shacl2code.model.Model(g)
+
+
+def test_model_ontology(model):
+    assert len(model.classes) > 0
+    assert len(model.ontologies) == 1
+
+    for c in model.classes:
+        assert c.ontology is model.ontologies[0]
+        for i in c.named_individuals:
+            assert i.ontology is model.ontologies[0]

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2292,3 +2292,10 @@ def test_version(model):
 
     assert model.VERSION_STRING == MODEL_VERSION
     assert model.VERSION == convert_version_string(MODEL_VERSION)
+
+
+def test_ontology(model):
+    classes = list(model.SHACLObject.CLASSES.values())
+    assert classes
+    for c in classes:
+        assert c.ONTOLOGY is not None

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -270,13 +270,13 @@ def python_usage_script(python_model_env, tmp_path):
             print({module_name}.enumType.foo)
 
             class OERecipeExtension({module_name}.extensible_abstract_class):
-                TYPE: ClassVar[str] = "http://example.org/recipe-extension"
+                TYPE: ClassVar[str] = "http://example.org/shacl2code-test/recipe-extension"
                 NODE_KIND: ClassVar[{module_name}.NodeKind] = {module_name}.NodeKind.BlankNodeOrIRI
                 PROPERTIES: ClassVar[List[{module_name}.ClassProp]] = [
                     {module_name}.ClassProp(
                         "is_native",
                         lambda: {module_name}.BooleanProp(),
-                        iri="http://example.org/is-native",
+                        iri="http://example.org/shacl2code-test/is-native",
                         max_count=1,
                     ),
                 ]
@@ -964,8 +964,8 @@ def type_tests(name, *typ):
         # Enumerated value
         (
             "test_class_enum_prop",
-            "http://example.org/enumType/foo",
-            "http://example.org/enumType/foo",
+            "http://example.org/shacl2code-test/enumType/foo",
+            "http://example.org/shacl2code-test/enumType/foo",
         ),
         ("test_class_enum_prop", "foo", ValueError),
         *type_tests("test_class_enum_prop", str),
@@ -1181,20 +1181,20 @@ def list_type_tests(name, *typ):
         (
             "test_class_enum_list_prop",
             [
-                "http://example.org/enumType/foo",
-                "http://example.org/enumType/bar",
-                "http://example.org/enumType/nolabel",
+                "http://example.org/shacl2code-test/enumType/foo",
+                "http://example.org/shacl2code-test/enumType/bar",
+                "http://example.org/shacl2code-test/enumType/nolabel",
             ],
             [
-                "http://example.org/enumType/foo",
-                "http://example.org/enumType/bar",
-                "http://example.org/enumType/nolabel",
+                "http://example.org/shacl2code-test/enumType/foo",
+                "http://example.org/shacl2code-test/enumType/bar",
+                "http://example.org/shacl2code-test/enumType/nolabel",
             ],
         ),
         (
             "test_class_enum_list_prop",
             [
-                "http://example.org/enumType/foo",
+                "http://example.org/shacl2code-test/enumType/foo",
                 "foo",
             ],
             ValueError,
@@ -1350,8 +1350,8 @@ def test_datetime_to_string(model, value, expect):
             "foo",
         ),
         (
-            "http://example.org/extensible-test-prop",
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             "foo",
             AttributeError,
         ),
@@ -1392,42 +1392,42 @@ def test_extensible_prop(model, test_context_url, prop, serkey, value, expect):
             None,
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             "foo",
             SAME_AS_VALUE,
             ["foo"],
             ["foo"],
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             1,
             SAME_AS_VALUE,
             [1],
             [1],
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             1.123,
             SAME_AS_VALUE,
             ["1.123"],
             [1.123],
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             object(),
             SAME_AS_VALUE,
             TypeError,
             None,
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             [1, "foo", 1.123],
             SAME_AS_VALUE,
             [1, "foo", "1.123"],
             [1, "foo", 1.123],
         ),
         (
-            "http://example.org/extensible-test-prop",
+            "http://example.org/shacl2code-test/extensible-test-prop",
             [object()],
             SAME_AS_VALUE,
             TypeError,
@@ -1501,14 +1501,14 @@ def test_extensible_deserialize(model, test_context_url):
 
     class ClosedExtension(model.extensible_class):
         CLOSED = True
-        TYPE = "http://example.org/closed-class"
+        TYPE = "http://example.org/shacl2code-test/closed-class"
 
     class OpenExtension(model.extensible_class):
-        TYPE = "http://example.org/open-class"
+        TYPE = "http://example.org/shacl2code-test/open-class"
 
-    TEST_TYPE = "http://example.org/test-extensible"
-    TEST_IRI = "http://example.org/test-key"
-    TEST_ID = "http://example.org/test-id"
+    TEST_TYPE = "http://example.org/shacl2code-test/test-extensible"
+    TEST_IRI = "http://example.org/shacl2code-test/test-key"
+    TEST_ID = "http://example.org/shacl2code-test/test-id"
 
     objset = deserialize_extension(
         {
@@ -1546,14 +1546,14 @@ def test_extensible_deserialize(model, test_context_url):
 
     objset = deserialize_extension(
         {
-            "@type": "http://example.org/closed-class",
+            "@type": "http://example.org/shacl2code-test/closed-class",
             "@id": TEST_ID,
         }
     )
     obj = objset.find_by_id(TEST_ID)
     assert obj is not None
     assert isinstance(obj, ClosedExtension)
-    assert obj.get_type() == "http://example.org/closed-class"
+    assert obj.get_type() == "http://example.org/shacl2code-test/closed-class"
     assert obj.get_compact_type() is None
 
     # Derived object is closed and cannot have arbitrary IRI assignment
@@ -1562,14 +1562,14 @@ def test_extensible_deserialize(model, test_context_url):
 
     objset = deserialize_extension(
         {
-            "@type": "http://example.org/open-class",
+            "@type": "http://example.org/shacl2code-test/open-class",
             "@id": TEST_ID,
         }
     )
     obj = objset.find_by_id(TEST_ID)
     assert obj is not None
     assert isinstance(obj, OpenExtension)
-    assert obj.get_type() == "http://example.org/open-class"
+    assert obj.get_type() == "http://example.org/shacl2code-test/open-class"
     assert obj.get_compact_type() is None
 
     # Derived object is open and can have arbitrary assignments
@@ -1578,14 +1578,14 @@ def test_extensible_deserialize(model, test_context_url):
 
 def test_enum_named_individuals(model):
     assert type(model.enumType.foo) is str
-    assert model.enumType.foo == "http://example.org/enumType/foo"
+    assert model.enumType.foo == "http://example.org/shacl2code-test/enumType/foo"
 
     c = model.test_class()
 
     assert model.enumType.NAMED_INDIVIDUALS == {
-        "foo": "http://example.org/enumType/foo",
-        "bar": "http://example.org/enumType/bar",
-        "nolabel": "http://example.org/enumType/nolabel",
+        "foo": "http://example.org/shacl2code-test/enumType/foo",
+        "bar": "http://example.org/shacl2code-test/enumType/bar",
+        "nolabel": "http://example.org/shacl2code-test/enumType/nolabel",
     }
 
     for name, value in model.enumType.NAMED_INDIVIDUALS.items():
@@ -1651,7 +1651,10 @@ def test_iri(model, roundtrip):
     assert isinstance(c, model.test_class)
 
     assert c._IRI["_id"] == "@id"
-    assert c._IRI["named_property"] == "http://example.org/test-class/named-property"
+    assert (
+        c._IRI["named_property"]
+        == "http://example.org/shacl2code-test/test-class/named-property"
+    )
 
     for name, iri in c._IRI.items():
         assert c[iri] == getattr(c, name)
@@ -1674,7 +1677,7 @@ def test_shacl(roundtrip):
         (
             URIRef("http://serialize.example.com/non-shape"),
             RDF.type,
-            URIRef("http://example.org/non-shape-class"),
+            URIRef("http://example.org/shacl2code-test/non-shape-class"),
         )
     )
 
@@ -1712,10 +1715,10 @@ def test_single_register(model):
 def test_objset_foreach_type(model, roundtrip):
     objset = model.SHACLObjectSet()
 
-    EXTENSION_ID = "http://example.org/custom-extension"
+    EXTENSION_ID = "http://example.org/shacl2code-test/custom-extension"
 
     class Extension(model.extensible_class):
-        TYPE = "http://example.org/custom-extension-class"
+        TYPE = "http://example.org/shacl2code-test/custom-extension-class"
 
     with roundtrip.open("r") as f:
         model.JSONLDDeserializer().read(f, objset)
@@ -1742,7 +1745,11 @@ def test_objset_foreach_type(model, roundtrip):
     assert set(objset.foreach_type(model.test_class, match_subclass=False)) == expect
     assert set(objset.foreach_type("test-class", match_subclass=False)) == expect
     assert (
-        set(objset.foreach_type("http://example.org/test-class", match_subclass=False))
+        set(
+            objset.foreach_type(
+                "http://example.org/shacl2code-test/test-class", match_subclass=False
+            )
+        )
         == expect
     )
 
@@ -1753,7 +1760,11 @@ def test_objset_foreach_type(model, roundtrip):
     assert set(objset.foreach_type(model.test_class, match_subclass=True)) == expect
     assert set(objset.foreach_type("test-class", match_subclass=True)) == expect
     assert (
-        set(objset.foreach_type("http://example.org/test-class", match_subclass=True))
+        set(
+            objset.foreach_type(
+                "http://example.org/shacl2code-test/test-class", match_subclass=True
+            )
+        )
         == expect
     )
 
@@ -1765,7 +1776,8 @@ def test_objset_foreach_type(model, roundtrip):
     assert (
         set(
             objset.foreach_type(
-                "http://example.org/extensible-class", match_subclass=False
+                "http://example.org/shacl2code-test/extensible-class",
+                match_subclass=False,
             )
         )
         == expect
@@ -1781,7 +1793,8 @@ def test_objset_foreach_type(model, roundtrip):
     assert (
         set(
             objset.foreach_type(
-                "http://example.org/extensible-class", match_subclass=True
+                "http://example.org/shacl2code-test/extensible-class",
+                match_subclass=True,
             )
         )
         == expect
@@ -1791,7 +1804,8 @@ def test_objset_foreach_type(model, roundtrip):
     assert (
         set(
             objset.foreach_type(
-                "http://example.org/custom-extension-class", match_subclass=False
+                "http://example.org/shacl2code-test/custom-extension-class",
+                match_subclass=False,
             )
         )
         == expect
@@ -1894,7 +1908,7 @@ def test_required_abstract_class_property(model, tmp_path):
 
 def test_extensible_abstract_class(model):
     class Extension(model.extensible_abstract_class):
-        TYPE = "http://example.org/custom-extension-class"
+        TYPE = "http://example.org/shacl2code-test/custom-extension-class"
 
     # Test that an extensible abstract class cannot be created
     with pytest.raises(NotImplementedError):
@@ -2000,7 +2014,7 @@ def test_varname_reserved_words(tmp_path):
     try:
         import temp_rwmodel as m  # noqa: PLC0415
 
-        cls = m.SHACLObject.CLASSES["http://example.org/test-rw-class"]
+        cls = m.SHACLObject.CLASSES["http://example.org/shacl2code-test/test-rw-class"]
 
         # Renamed kwargs must work at construction time
         obj = cls(get_id_="a", set_id_="b", encode_="c", class_="d")
@@ -2012,8 +2026,8 @@ def test_varname_reserved_words(tmp_path):
         # SHACLObject.get_id() must still return the object IRI,
         # not the value of the prop (get_id_)
         assert obj.get_id() is None
-        obj.set_id("http://example.org/obj")
-        assert obj.get_id() == "http://example.org/obj"
+        obj.set_id("http://example.org/shacl2code-test/obj")
+        assert obj.get_id() == "http://example.org/shacl2code-test/obj"
     finally:
         sys.path = old_path
         for mod in list(sys.modules):
@@ -2024,12 +2038,12 @@ def test_varname_reserved_words(tmp_path):
 def test_extensible_properties(model, model_context_url):
 
     class Extension(model.extensible_class):
-        TYPE = "http://example.org/extension"
+        TYPE = "http://example.org/shacl2code-test/extension"
         PROPERTIES = [
             model.ClassProp(
                 "string_prop",
                 lambda: model.StringProp(),
-                "http://example.org/string-prop",
+                "http://example.org/shacl2code-test/string-prop",
                 min_count=1,
             ),
         ]
@@ -2038,7 +2052,7 @@ def test_extensible_properties(model, model_context_url):
         "@context": [
             model_context_url,
             {
-                "prefix": "http://example.org/",
+                "prefix": "http://example.org/shacl2code-test/",
             },
         ],
         "@graph": [
@@ -2056,13 +2070,13 @@ def test_extensible_properties(model, model_context_url):
     d = model.JSONLDDeserializer()
     d.deserialize_data(DATA, objset)
 
-    e = objset.find_by_id("http://example.org/e")
+    e = objset.find_by_id("http://example.org/shacl2code-test/e")
     assert e
     assert isinstance(e, Extension)
     assert e.string_prop == "foo"
-    assert e["http://example.org/string-prop"] == "foo"
-    assert e._id == "http://example.org/e"
-    assert e["http://example.org/extra-data"] == ["bar"]
+    assert e["http://example.org/shacl2code-test/string-prop"] == "foo"
+    assert e._id == "http://example.org/shacl2code-test/e"
+    assert e["http://example.org/shacl2code-test/extra-data"] == ["bar"]
 
     # Ensure the context is preserved
     s = model.JSONLDSerializer()
@@ -2145,33 +2159,33 @@ def test_object_iter(model):
 
     assert data == {
         "@id": "http://example.com/link-class",
-        "http://example.org/encode": None,
-        "http://example.org/import": None,
-        "http://example.org/test-class/anyuri-prop": None,
-        "http://example.org/test-class/boolean-prop": True,
-        "http://example.org/test-class/class-list-prop": [],
-        "http://example.org/test-class/class-prop": None,
-        "http://example.org/test-class/class-prop-no-class": None,
-        "http://example.org/test-class/datetime-list-prop": [],
-        "http://example.org/test-class/datetime-scalar-prop": None,
-        "http://example.org/test-class/datetimestamp-scalar-prop": None,
-        "http://example.org/test-class/enum-list-prop": [],
-        "http://example.org/test-class/enum-prop": None,
-        "http://example.org/test-class/enum-prop-no-class": None,
-        "http://example.org/test-class/float-prop": None,
-        "http://example.org/test-class/integer-prop": None,
-        "http://example.org/test-class/named-property": None,
-        "http://example.org/test-class/non-shape": None,
-        "http://example.org/test-class/nonnegative-integer-prop": None,
-        "http://example.org/test-class/positive-integer-prop": None,
-        "http://example.org/test-class/regex": None,
-        "http://example.org/test-class/regex-datetime": None,
-        "http://example.org/test-class/regex-datetimestamp": None,
-        "http://example.org/test-class/regex-list": [],
-        "http://example.org/test-class/split-string-prop": None,
-        "http://example.org/test-class/string-list-no-datatype": [],
-        "http://example.org/test-class/string-list-prop": ["a", "b"],
-        "http://example.org/test-class/string-scalar-prop": "foo",
+        "http://example.org/shacl2code-test/encode": None,
+        "http://example.org/shacl2code-test/import": None,
+        "http://example.org/shacl2code-test/test-class/anyuri-prop": None,
+        "http://example.org/shacl2code-test/test-class/boolean-prop": True,
+        "http://example.org/shacl2code-test/test-class/class-list-prop": [],
+        "http://example.org/shacl2code-test/test-class/class-prop": None,
+        "http://example.org/shacl2code-test/test-class/class-prop-no-class": None,
+        "http://example.org/shacl2code-test/test-class/datetime-list-prop": [],
+        "http://example.org/shacl2code-test/test-class/datetime-scalar-prop": None,
+        "http://example.org/shacl2code-test/test-class/datetimestamp-scalar-prop": None,
+        "http://example.org/shacl2code-test/test-class/enum-list-prop": [],
+        "http://example.org/shacl2code-test/test-class/enum-prop": None,
+        "http://example.org/shacl2code-test/test-class/enum-prop-no-class": None,
+        "http://example.org/shacl2code-test/test-class/float-prop": None,
+        "http://example.org/shacl2code-test/test-class/integer-prop": None,
+        "http://example.org/shacl2code-test/test-class/named-property": None,
+        "http://example.org/shacl2code-test/test-class/non-shape": None,
+        "http://example.org/shacl2code-test/test-class/nonnegative-integer-prop": None,
+        "http://example.org/shacl2code-test/test-class/positive-integer-prop": None,
+        "http://example.org/shacl2code-test/test-class/regex": None,
+        "http://example.org/shacl2code-test/test-class/regex-datetime": None,
+        "http://example.org/shacl2code-test/test-class/regex-datetimestamp": None,
+        "http://example.org/shacl2code-test/test-class/regex-list": [],
+        "http://example.org/shacl2code-test/test-class/split-string-prop": None,
+        "http://example.org/shacl2code-test/test-class/string-list-no-datatype": [],
+        "http://example.org/shacl2code-test/test-class/string-list-prop": ["a", "b"],
+        "http://example.org/shacl2code-test/test-class/string-scalar-prop": "foo",
     }
 
 
@@ -2204,12 +2218,14 @@ def test_object_prop_set_coercion(model):
     c = model.test_class()
 
     # Assigning string should remain string
-    c.test_class_class_prop = "http://example.org/assigned-iri"
+    c.test_class_class_prop = "http://example.org/shacl2code-test/assigned-iri"
     assert isinstance(c.test_class_class_prop, str)
-    assert c.test_class_class_prop == "http://example.org/assigned-iri"
+    assert c.test_class_class_prop == "http://example.org/shacl2code-test/assigned-iri"
 
     # Assigning an object should preserve the object instance without str() coercion
-    embedded_obj = model.test_class(_id="http://example.org/embedded-obj")
+    embedded_obj = model.test_class(
+        _id="http://example.org/shacl2code-test/embedded-obj"
+    )
     c.test_class_class_prop = embedded_obj
     assert isinstance(c.test_class_class_prop, model.test_class)  # check if same class
     assert c.test_class_class_prop is embedded_obj  # check if same object
@@ -2264,8 +2280,8 @@ def test_introspection_extensible(model):
     assert "extensible_class_required" in props
 
     # IRI-keyed extensible properties must NOT appear in dir()
-    c["http://example.org/extensible-test-prop"] = "test-value"
-    assert "http://example.org/extensible-test-prop" not in dir(c)
+    c["http://example.org/shacl2code-test/extensible-test-prop"] = "test-value"
+    assert "http://example.org/shacl2code-test/extensible-test-prop" not in dir(c)
 
 
 def test_version(model):

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -1950,9 +1950,9 @@ def test_deprecated_class(model):
         model.test_deprecated_class()
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_deprecated_property(model):
-    c = model.test_deprecated_class()
+    with pytest.warns(DeprecationWarning):
+        c = model.test_deprecated_class()
 
     with pytest.deprecated_call():
         c.test_deprecated_class_deprecated_string_prop = "foo"

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2299,3 +2299,10 @@ def test_ontology(model):
     assert classes
     for c in classes:
         assert c.ONTOLOGY is not None
+
+
+def test_prerelease_warning(model):
+    model.SHACL2CODE_TEST.is_prerelease = True
+
+    with pytest.warns(FutureWarning):
+        model.test_class()

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -555,8 +555,8 @@ RUST_STRING = '"string".to_string()'
         # Enumerated value
         (
             "test_class_enum_prop",
-            '"http://example.org/enumType/foo".to_string()',
-            "http://example.org/enumType/foo",
+            '"http://example.org/shacl2code-test/enumType/foo".to_string()',
+            "http://example.org/shacl2code-test/enumType/foo",
         ),
         ("test_class_enum_prop", RUST_STRING, Progress.VALIDATION_FAILS),
         # Integer value

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-from testfixtures import jsonvalidation, timetests
 from shacl2code.lang.rust import (
     is_effectively_extensible,
     prop_ctx_name,
@@ -21,6 +20,8 @@ from shacl2code.lang.rust import (
     type_name,
     varname,
 )
+
+from testfixtures import jsonvalidation, timetests
 
 THIS_FILE = Path(__file__)
 THIS_DIR = THIS_FILE.parent


### PR DESCRIPTION
Implements support for detecting OWL ontologies in a model, and adds an annotation to them that allows them to be marked as pre-release, which issues a warning when used in Python code