### PR TITLE
Rust: Add static analysis for generated Rust bindings

### DIFF
--- a/.github/workflows/coverage-generate.yaml
+++ b/.github/workflows/coverage-generate.yaml
@@ -37,6 +37,9 @@ jobs:
           sudo apt install -y build-essential doxygen graphviz
           npm install -g jsonld-cli
           npm --prefix scripts ci
+      - name: Install Rust static analysis tools
+        run: |
+          rustup component add clippy
       - name: Install package
         run: |
           pip install -e .[dev]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,9 @@ jobs:
         run: |
           brew update
           brew install doxygen gcc go graphviz
+      - name: Install Rust static analysis tools
+        run: |
+          rustup component add clippy
       - name: Build package
         run: |
           python -m build

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -447,7 +447,7 @@ class TestOutput:
 
 
 @pytest.mark.parametrize(*RUST_MODEL_TESTS)
-class TestCheckType:
+class TestStaticAnalysis:
     """
     Static analysis checks for the generated Rust code
     """

--- a/tests/test_rust.py
+++ b/tests/test_rust.py
@@ -407,33 +407,59 @@ def link_test(test_lib, tmp_path_factory):
     yield f
 
 
-@pytest.mark.parametrize(
+RUST_MODEL_TESTS = (
     "args",
     [
         ["--input", TEST_MODEL],
         ["--input", TEST_MODEL, "--context-url", TEST_CONTEXT, SPDX3_CONTEXT_URL],
     ],
 )
+
+
+def _build_rust_module(tmp_path, model_server, args):
+    subprocess.run(
+        [
+            "shacl2code",
+            "generate",
+            "--context",
+            model_server + "/test-context.json",
+        ]
+        + args
+        + [
+            "rust",
+            "--output",
+            tmp_path / "shacl_model",
+        ],
+        check=True,
+    )
+
+
+@pytest.mark.parametrize(*RUST_MODEL_TESTS)
 class TestOutput:
     def test_output_compile(self, tmp_path, model_server, args):
-        subprocess.run(
-            [
-                "shacl2code",
-                "generate",
-                "--context",
-                model_server + "/test-context.json",
-            ]
-            + args
-            + [
-                "rust",
-                "--output",
-                tmp_path / "shacl_model",
-            ],
-            check=True,
-        )
+        _build_rust_module(tmp_path, model_server, args)
 
         subprocess.run(
             ["cargo", "build"],
+            cwd=tmp_path / "shacl_model",
+            check=True,
+        )
+
+
+@pytest.mark.parametrize(*RUST_MODEL_TESTS)
+class TestCheckType:
+    """
+    Static analysis checks for the generated Rust code
+    """
+
+    def test_clippy(self, tmp_path, model_server, args):
+        """
+        cargo clippy static analysis
+        """
+        _build_rust_module(tmp_path, model_server, args)
+
+        subprocess.run(
+            ["cargo", "clippy", "--all-targets", "--", "-D", "warnings"],
             cwd=tmp_path / "shacl_model",
             check=True,
         )


### PR DESCRIPTION
Add Rust `cargo clippy` to tests.

See #120 