### PR TITLE
Skip pyshac 0.40.0 in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "mypy >= 1.19.1",  # latest version for Python 3.9 is 1.19.x
     "pyrefly >= 0.55.0",
     "pyright >= 1.1.403",
-    "pyshacl >= 0.25.0",
+    "pyshacl >= 0.25.0, != 0.40.0",  # 0.40.0 uses `str | X` at runtime, breaks Python < 3.10
     "pytest >= 7.4",
     "pytest-cov >= 4.1",
     "pytest-xdist >= 3.5",


### PR DESCRIPTION
pyshacl 0.40.0 uses `str | X` union syntax at runtime, which will break tests on Python < 3.10.

This issue is fixed in pyshacl 0.40.1.
So we will skip pyshacl 0.40.0 in dev dependency list.